### PR TITLE
Add LAST_INSERT_ID to MySQL upsert query

### DIFF
--- a/queries/query_builders.go
+++ b/queries/query_builders.go
@@ -231,6 +231,13 @@ func BuildUpsertQueryMySQL(dia Dialect, tableName string, update, whitelist []st
 		buf.WriteByte(')')
 	}
 
+	quoted := strmangle.IdentQuote(dia.LQ, dia.RQ, "id")
+	buf.WriteByte(',')
+	buf.WriteString(quoted)
+	buf.WriteString(" = LAST_INSERT_ID(")
+	buf.WriteString(quoted)
+	buf.WriteByte(')')
+
 	return buf.String()
 }
 


### PR DESCRIPTION
It fixes an error caused by a query that uses the last insert ID to populate default values for structs after an upsert query at https://github.com/vattle/sqlboiler/blob/master/templates/17_upsert.tpl#L200, currently using `0` as the ID:

```
models: unable to populate default values for <model>: sql: no rows in result set
```