### PR TITLE
fix null.Int64 when bigint is signed

### DIFF
--- a/bdb/drivers/mysql.go
+++ b/bdb/drivers/mysql.go
@@ -306,7 +306,7 @@ func (m *MySQLDriver) TranslateColumnType(c bdb.Column) bdb.Column {
 			if unsigned {
 				c.Type = "null.Uint64"
 			} else {
-				c.Type = "null.Uint64"
+				c.Type = "null.Int64"
 			}
 		case "float":
 			c.Type = "null.Float32"


### PR DESCRIPTION
BIGINT should distinguish signed or unsigned for type int64 or uint64.