### PR TITLE
use interface to enable custom Tx types

### DIFF
--- a/boil/db.go
+++ b/boil/db.go
@@ -19,7 +19,7 @@ type Transactor interface {
 
 // Beginner begins transactions.
 type Beginner interface {
-	Begin() (*sql.Tx, error)
+	Begin() (Transactor, error)
 }
 
 // Begin a transaction


### PR DESCRIPTION
Use Transactor interface instead of *sql.Tx so developers are free to use a custom Tx type.