### PR TITLE
Fix HAVING clause to join multiple conditions

### DIFF
--- a/queries/_fixtures/08.sql
+++ b/queries/_fixtures/08.sql
@@ -1,1 +1,1 @@
-SELECT * FROM "a" WHERE (a=$1 or b=$2) AND (c=$3) GROUP BY id, name HAVING id <> $4, length(name, $5) > $6;
+SELECT * FROM "a" WHERE (a=$1 or b=$2) AND (c=$3) GROUP BY id, name HAVING id <> $4 AND length(name, $5) > $6;

--- a/queries/query_builders.go
+++ b/queries/query_builders.go
@@ -337,7 +337,7 @@ func writeModifiers(q *Query, buf *bytes.Buffer, args *[]interface{}) {
 		fmt.Fprintf(havingBuf, " HAVING ")
 		for i, j := range q.having {
 			if i > 0 {
-				fmt.Fprintf(havingBuf, ", ")
+				fmt.Fprintf(havingBuf, " AND ")
 			}
 			fmt.Fprintf(havingBuf, j.clause)
 			*args = append(*args, j.args...)


### PR DESCRIPTION
When having clause has multiple conditions, they are joined by `,`.
Then, the following error occurs.
```
mysql> SELECT * FROM personal GROUP BY id, name HAVING id <>1, length(name) > 5;
ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ' length(name) > 5' at line 1
```

I think they should be joined by `AND` or `OR`.
I support `AND` for the time being.

```
mysql> SELECT * FROM personal GROUP BY id, name HAVING id <>1 AND length(name) > 5;
+------+--------+
| id   | name   |
+------+--------+
|    2 | foobar |
+------+--------+
1 row in set (0.00 sec)
```