### PR TITLE
fix mysql type TIME should not covert to time.Time

### DIFF
--- a/bdb/drivers/mysql.go
+++ b/bdb/drivers/mysql.go
@@ -314,7 +314,7 @@ func (m *MySQLDriver) TranslateColumnType(c bdb.Column) bdb.Column {
 			c.Type = "null.Float64"
 		case "boolean", "bool":
 			c.Type = "null.Bool"
-		case "date", "datetime", "timestamp", "time":
+		case "date", "datetime", "timestamp":
 			c.Type = "null.Time"
 		case "binary", "varbinary", "tinyblob", "blob", "mediumblob", "longblob":
 			c.Type = "null.Bytes"
@@ -364,7 +364,7 @@ func (m *MySQLDriver) TranslateColumnType(c bdb.Column) bdb.Column {
 			c.Type = "float64"
 		case "boolean", "bool":
 			c.Type = "bool"
-		case "date", "datetime", "timestamp", "time":
+		case "date", "datetime", "timestamp":
 			c.Type = "time.Time"
 		case "binary", "varbinary", "tinyblob", "blob", "mediumblob", "longblob":
 			c.Type = "[]byte"


### PR DESCRIPTION
As per mysql driver document.

https://github.com/go-sql-driver/mysql#parsetime
```
`parseTime=true` changes the output type of `DATE` and `DATETIME` values to `time.Time` instead of `[]byte` / `string`
```
However type `TIME` is scaned as raw bytes.
https://github.com/go-sql-driver/mysql/blob/master/fields.go#L124

Therefore, models throw out an error when converting `TIME` type column to `time.Time`