### PR TITLE
Query Select Hooks

### DIFF
--- a/bdb/drivers/mysql.go
+++ b/bdb/drivers/mysql.go
@@ -316,7 +316,7 @@ func (m *MySQLDriver) TranslateColumnType(c bdb.Column) bdb.Column {
 			c.Type = "null.Bool"
 		case "date", "datetime", "timestamp", "time":
 			c.Type = "null.Time"
-		case "binary", "varbinary", "tinyblob", "blob", "mediumblob", "longblob":
+		case "binary", "varbinary", "tinyblob", "blob", "mediumblob", "longblob", "geometry", "point", "linestring", "polygon", "multipoint", "multilinestring", "multipolygon", "geometrycollection":
 			c.Type = "null.Bytes"
 		case "json":
 			c.Type = "types.JSON"
@@ -366,7 +366,7 @@ func (m *MySQLDriver) TranslateColumnType(c bdb.Column) bdb.Column {
 			c.Type = "bool"
 		case "date", "datetime", "timestamp", "time":
 			c.Type = "time.Time"
-		case "binary", "varbinary", "tinyblob", "blob", "mediumblob", "longblob":
+		case "binary", "varbinary", "tinyblob", "blob", "mediumblob", "longblob", "geometry", "point", "linestring", "polygon", "multipoint", "multilinestring", "multipolygon", "geometrycollection":
 			c.Type = "[]byte"
 		case "json":
 			c.Type = "types.JSON"

--- a/boil/hooks.go
+++ b/boil/hooks.go
@@ -15,3 +15,15 @@ const (
 	AfterDeleteHook
 	AfterUpsertHook
 )
+
+// QueryHookPoint is the point in time at which we hook query
+type QueryHookPoint int
+
+// the query hook point constants
+const (
+	InsertHook QueryHookPoint = iota + 1
+	SelectHook
+	UpdateHook
+	DeleteHook
+	UpsertHook
+)

--- a/boilingcore/text_helpers.go
+++ b/boilingcore/text_helpers.go
@@ -19,6 +19,7 @@ type TxtToOne struct {
 	}
 
 	ForeignTable struct {
+		Name        string
 		NameGo       string
 		NamePluralGo string
 		ColumnNameGo string
@@ -44,6 +45,7 @@ func txtsFromFKey(tables []bdb.Table, table bdb.Table, fkey bdb.ForeignKey) TxtT
 	r.LocalTable.NameGo = strmangle.TitleCase(strmangle.Singular(table.Name))
 	r.LocalTable.ColumnNameGo = strmangle.TitleCase(strmangle.Singular(fkey.Column))
 
+	r.ForeignTable.Name = strmangle.CamelCase(strmangle.Singular(fkey.ForeignTable))
 	r.ForeignTable.NameGo = strmangle.TitleCase(strmangle.Singular(fkey.ForeignTable))
 	r.ForeignTable.NamePluralGo = strmangle.TitleCase(strmangle.Plural(fkey.ForeignTable))
 	r.ForeignTable.ColumnName = fkey.ForeignColumn

--- a/boilingcore/text_helpers.go
+++ b/boilingcore/text_helpers.go
@@ -19,7 +19,7 @@ type TxtToOne struct {
 	}
 
 	ForeignTable struct {
-		Name        string
+		Name         string
 		NameGo       string
 		NamePluralGo string
 		ColumnNameGo string
@@ -115,6 +115,7 @@ type TxtToMany struct {
 	}
 
 	ForeignTable struct {
+		Name              string
 		NameGo            string
 		NamePluralGo      string
 		NameHumanReadable string
@@ -142,6 +143,7 @@ func txtsFromToMany(tables []bdb.Table, table bdb.Table, rel bdb.ToManyRelations
 
 	foreignNameSingular := strmangle.Singular(rel.ForeignTable)
 	r.ForeignTable.NamePluralGo = strmangle.TitleCase(strmangle.Plural(rel.ForeignTable))
+	r.ForeignTable.Name = strmangle.CamelCase(foreignNameSingular)
 	r.ForeignTable.NameGo = strmangle.TitleCase(foreignNameSingular)
 	r.ForeignTable.ColumnNameGo = strmangle.TitleCase(rel.ForeignColumn)
 	r.ForeignTable.Slice = fmt.Sprintf("%sSlice", strmangle.TitleCase(foreignNameSingular))

--- a/boilingcore/text_helpers_test.go
+++ b/boilingcore/text_helpers_test.go
@@ -26,6 +26,7 @@ func TestTxtsFromOne(t *testing.T) {
 	expect.LocalTable.NameGo = "Jet"
 	expect.LocalTable.ColumnNameGo = "PilotID"
 
+	expect.ForeignTable.Name = "pilot"
 	expect.ForeignTable.NameGo = "Pilot"
 	expect.ForeignTable.NamePluralGo = "Pilots"
 	expect.ForeignTable.ColumnName = "id"
@@ -48,6 +49,7 @@ func TestTxtsFromOne(t *testing.T) {
 	expect.LocalTable.NameGo = "Jet"
 	expect.LocalTable.ColumnNameGo = "AirportID"
 
+	expect.ForeignTable.Name = "airport"
 	expect.ForeignTable.NameGo = "Airport"
 	expect.ForeignTable.NamePluralGo = "Airports"
 	expect.ForeignTable.ColumnName = "id"
@@ -97,6 +99,7 @@ func TestTxtsFromOneToOne(t *testing.T) {
 	expect.LocalTable.NameGo = "Pilot"
 	expect.LocalTable.ColumnNameGo = "ID"
 
+	expect.ForeignTable.Name = "jet"
 	expect.ForeignTable.NameGo = "Jet"
 	expect.ForeignTable.NamePluralGo = "Jets"
 	expect.ForeignTable.ColumnName = "pilot_id"
@@ -127,6 +130,7 @@ func TestTxtsFromMany(t *testing.T) {
 	expect.LocalTable.NameGo = "Pilot"
 	expect.LocalTable.ColumnNameGo = "ID"
 
+	expect.ForeignTable.Name = "license"
 	expect.ForeignTable.NameGo = "License"
 	expect.ForeignTable.NamePluralGo = "Licenses"
 	expect.ForeignTable.NameHumanReadable = "licenses"
@@ -147,6 +151,7 @@ func TestTxtsFromMany(t *testing.T) {
 	expect.LocalTable.NameGo = "Pilot"
 	expect.LocalTable.ColumnNameGo = "ID"
 
+	expect.ForeignTable.Name = "language"
 	expect.ForeignTable.NameGo = "Language"
 	expect.ForeignTable.NamePluralGo = "Languages"
 	expect.ForeignTable.NameHumanReadable = "languages"

--- a/templates/01_types.tpl
+++ b/templates/01_types.tpl
@@ -19,6 +19,9 @@ type (
 	{{if not .NoHooks -}}
 	// {{$tableNameSingular}}Hook is the signature for custom {{$tableNameSingular}} hook methods
 	{{$tableNameSingular}}Hook func(boil.Executor, *{{$tableNameSingular}}) error
+
+	// {{$tableNameSingular}}QueryHook is the signature for custom {{$varNameSingular}}Query hook methods
+	{{$tableNameSingular}}QueryHook func(boil.Executor, *queries.Query) error
 	{{- end}}
 
 	{{$varNameSingular}}Query struct {

--- a/templates/02_hooks.tpl
+++ b/templates/02_hooks.tpl
@@ -134,4 +134,81 @@ func Add{{$tableNameSingular}}Hook(hookPoint boil.HookPoint, {{$varNameSingular}
 			{{$varNameSingular}}AfterUpsertHooks = append({{$varNameSingular}}AfterUpsertHooks, {{$varNameSingular}}Hook)
 	}
 }
+
+var {{$varNameSingular}}QueryInsertHooks []{{$tableNameSingular}}QueryHook
+var {{$varNameSingular}}QuerySelectHooks []{{$tableNameSingular}}QueryHook
+var {{$varNameSingular}}QueryUpdateHooks []{{$tableNameSingular}}QueryHook
+var {{$varNameSingular}}QueryDeleteHooks []{{$tableNameSingular}}QueryHook
+var {{$varNameSingular}}QueryUpsertHooks []{{$tableNameSingular}}QueryHook
+
+// doInsertHooks executes all "insert" hooks.
+func (q {{$varNameSingular}}Query) doInsertHooks(exec boil.Executor) (err error) {
+	for _, hook := range {{$varNameSingular}}QueryInsertHooks {
+		if err := hook(exec, q.Query); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// doSelectHooks executes all "select" hooks.
+func (q {{$varNameSingular}}Query) doSelectHooks(exec boil.Executor) (err error) {
+	for _, hook := range {{$varNameSingular}}QuerySelectHooks {
+		if err := hook(exec, q.Query); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// doUpdateHooks executes all "update" hooks.
+func (q {{$varNameSingular}}Query) doUpdateHooks(exec boil.Executor) (err error) {
+	for _, hook := range {{$varNameSingular}}QueryUpdateHooks {
+		if err := hook(exec, q.Query); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// doDeleteHooks executes all "delete" hooks.
+func (q {{$varNameSingular}}Query) doDeleteHooks(exec boil.Executor) (err error) {
+	for _, hook := range {{$varNameSingular}}QueryDeleteHooks {
+		if err := hook(exec, q.Query); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// doUpsertHooks executes all "upsert" hooks.
+func (q {{$varNameSingular}}Query) doUpsertHooks(exec boil.Executor) (err error) {
+	for _, hook := range {{$varNameSingular}}QueryUpsertHooks {
+		if err := hook(exec, q.Query); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Add{{$tableNameSingular}}QueryHook registers your query hook function for all future operations.
+func Add{{$tableNameSingular}}QueryHook(hookPoint boil.QueryHookPoint, {{$varNameSingular}}QueryHook {{$tableNameSingular}}QueryHook) {
+	switch hookPoint {
+		case boil.InsertHook:
+			{{$varNameSingular}}QueryInsertHooks = append({{$varNameSingular}}QueryInsertHooks, {{$varNameSingular}}QueryHook)
+		case boil.SelectHook:
+			{{$varNameSingular}}QuerySelectHooks = append({{$varNameSingular}}QuerySelectHooks, {{$varNameSingular}}QueryHook)
+		case boil.UpdateHook:
+			{{$varNameSingular}}QueryUpdateHooks = append({{$varNameSingular}}QueryUpdateHooks, {{$varNameSingular}}QueryHook)
+		case boil.DeleteHook:
+			{{$varNameSingular}}QueryDeleteHooks = append({{$varNameSingular}}QueryDeleteHooks, {{$varNameSingular}}QueryHook)
+		case boil.UpsertHook:
+			{{$varNameSingular}}QueryUpsertHooks = append({{$varNameSingular}}QueryUpsertHooks, {{$varNameSingular}}QueryHook)
+	}
+}
 {{- end}}

--- a/templates/03_finishers.tpl
+++ b/templates/03_finishers.tpl
@@ -14,6 +14,12 @@ func (q {{$varNameSingular}}Query) OneP() (*{{$tableNameSingular}}) {
 func (q {{$varNameSingular}}Query) One() (*{{$tableNameSingular}}, error) {
 	o := &{{$tableNameSingular}}{}
 
+	{{if not .NoHooks -}}
+	if err := q.doSelectHooks(queries.GetExecutor(q.Query)); nil != err {
+		return nil, err
+	}
+	{{- end}}
+
 	queries.SetLimit(q.Query, 1)
 
 	err := q.Bind(o)
@@ -47,6 +53,12 @@ func (q {{$varNameSingular}}Query) AllP() {{$tableNameSingular}}Slice {
 func (q {{$varNameSingular}}Query) All() ({{$tableNameSingular}}Slice, error) {
 	var o []*{{$tableNameSingular}}
 
+	{{if not .NoHooks -}}
+	if err := q.doSelectHooks(queries.GetExecutor(q.Query)); nil != err {
+		return nil, err
+	}
+	{{- end}}
+
 	err := q.Bind(&o)
 	if err != nil {
 		return nil, errors.Wrap(err, "{{.PkgName}}: failed to assign all query results to {{$tableNameSingular}} slice")
@@ -79,6 +91,12 @@ func (q {{$varNameSingular}}Query) CountP() int64 {
 func (q {{$varNameSingular}}Query) Count() (int64, error) {
 	var count int64
 
+	{{if not .NoHooks -}}
+	if err := q.doSelectHooks(queries.GetExecutor(q.Query)); nil != err {
+		return 0, err
+	}
+	{{- end}}
+
 	queries.SetSelect(q.Query, nil)
 	queries.SetCount(q.Query)
 
@@ -103,6 +121,12 @@ func (q {{$varNameSingular}}Query) ExistsP() bool {
 // Exists checks if the row exists in the table.
 func (q {{$varNameSingular}}Query) Exists() (bool, error) {
 	var count int64
+
+	{{if not .NoHooks -}}
+	if err := q.doSelectHooks(queries.GetExecutor(q.Query)); nil != err {
+		return false, err
+	}
+	{{- end}}
 
 	queries.SetCount(q.Query)
 	queries.SetLimit(q.Query, 1)

--- a/templates/07_relationship_to_one_eager.tpl
+++ b/templates/07_relationship_to_one_eager.tpl
@@ -43,7 +43,14 @@ func ({{$varNameSingular}}L) Load{{$txt.Function.Name}}(e boil.Executor, singula
 		fmt.Fprintf(boil.DebugWriter, "%s\n%v\n", query, args)
 	}
 
-	results, err := e.Query(query, args...)
+	q := queries.Raw(e, query, args...)
+	{{if not $dot.NoHooks -}}
+	if err := ({{$varNameSingular}}Query{q}).doSelectHooks(queries.GetExecutor(q)); nil != err {
+		return err
+	}
+	{{- end}}
+
+	results, err := q.Query()
 	if err != nil {
 		return errors.Wrap(err, "failed to eager load {{$txt.ForeignTable.NameGo}}")
 	}

--- a/templates/07_relationship_to_one_eager.tpl
+++ b/templates/07_relationship_to_one_eager.tpl
@@ -45,7 +45,7 @@ func ({{$varNameSingular}}L) Load{{$txt.Function.Name}}(e boil.Executor, singula
 
 	q := queries.Raw(e, query, args...)
 	{{if not $dot.NoHooks -}}
-	if err := ({{$varNameSingular}}Query{q}).doSelectHooks(queries.GetExecutor(q)); nil != err {
+	if err := ({{$txt.ForeignTable.Name}}Query{q}).doSelectHooks(queries.GetExecutor(q)); nil != err {
 		return err
 	}
 	{{- end}}

--- a/templates/07_relationship_to_one_eager.tpl
+++ b/templates/07_relationship_to_one_eager.tpl
@@ -41,10 +41,6 @@ func ({{$varNameSingular}}L) Load{{$txt.Function.Name}}(e boil.Executor, singula
 		),
 	)
 
-	if boil.DebugMode {
-		// fmt.Fprintf(boil.DebugWriter, "%s\n%v\n", query, args)
-	}
-
 	{{if not $dot.NoHooks -}}
 	if err := q.doSelectHooks(queries.GetExecutor(q.Query)); nil != err {
 		return err

--- a/templates/08_relationship_one_to_one_eager.tpl
+++ b/templates/08_relationship_one_to_one_eager.tpl
@@ -43,7 +43,14 @@ func ({{$varNameSingular}}L) Load{{$txt.Function.Name}}(e boil.Executor, singula
 		fmt.Fprintf(boil.DebugWriter, "%s\n%v\n", query, args)
 	}
 
-	results, err := e.Query(query, args...)
+	q := queries.Raw(e, query, args...)
+	{{if not $dot.NoHooks -}}
+	if err := ({{$varNameSingular}}Query{q}).doSelectHooks(queries.GetExecutor(q)); nil != err {
+		return err
+	}
+	{{- end}}
+
+	results, err := q.Query()
 	if err != nil {
 		return errors.Wrap(err, "failed to eager load {{$txt.ForeignTable.NameGo}}")
 	}

--- a/templates/08_relationship_one_to_one_eager.tpl
+++ b/templates/08_relationship_one_to_one_eager.tpl
@@ -45,7 +45,7 @@ func ({{$varNameSingular}}L) Load{{$txt.Function.Name}}(e boil.Executor, singula
 
 	q := queries.Raw(e, query, args...)
 	{{if not $dot.NoHooks -}}
-	if err := ({{$varNameSingular}}Query{q}).doSelectHooks(queries.GetExecutor(q)); nil != err {
+	if err := ({{$txt.ForeignTable.Name}}Query{q}).doSelectHooks(queries.GetExecutor(q)); nil != err {
 		return err
 	}
 	{{- end}}

--- a/templates/08_relationship_one_to_one_eager.tpl
+++ b/templates/08_relationship_one_to_one_eager.tpl
@@ -41,10 +41,6 @@ func ({{$varNameSingular}}L) Load{{$txt.Function.Name}}(e boil.Executor, singula
 		),
 	)
 
-	if boil.DebugMode {
-		// fmt.Fprintf(boil.DebugWriter, "%s\n%v\n", query, args)
-	}
-
 	{{if not $dot.NoHooks -}}
 	if err := q.doSelectHooks(queries.GetExecutor(q.Query)); nil != err {
 		return err

--- a/templates/09_relationship_to_many_eager.tpl
+++ b/templates/09_relationship_to_many_eager.tpl
@@ -52,7 +52,14 @@ func ({{$varNameSingular}}L) Load{{$txt.Function.Name}}(e boil.Executor, singula
 		fmt.Fprintf(boil.DebugWriter, "%s\n%v\n", query, args)
 	}
 
-	results, err := e.Query(query, args...)
+	q := queries.Raw(e, query, args...)
+	{{if not $dot.NoHooks -}}
+	if err := ({{$varNameSingular}}Query{q}).doSelectHooks(queries.GetExecutor(q)); nil != err {
+		return err
+	}
+	{{- end}}
+
+	results, err := q.Query()
 	if err != nil {
 		return errors.Wrap(err, "failed to eager load {{.ForeignTable}}")
 	}

--- a/templates/09_relationship_to_many_eager.tpl
+++ b/templates/09_relationship_to_many_eager.tpl
@@ -54,7 +54,7 @@ func ({{$varNameSingular}}L) Load{{$txt.Function.Name}}(e boil.Executor, singula
 
 	q := queries.Raw(e, query, args...)
 	{{if not $dot.NoHooks -}}
-	if err := ({{$varNameSingular}}Query{q}).doSelectHooks(queries.GetExecutor(q)); nil != err {
+	if err := ({{$txt.ForeignTable.Name}}Query{q}).doSelectHooks(queries.GetExecutor(q)); nil != err {
 		return err
 	}
 	{{- end}}

--- a/templates/14_find.tpl
+++ b/templates/14_find.tpl
@@ -33,6 +33,12 @@ func Find{{$tableNameSingular}}(exec boil.Executor, {{$pkArgs}}, selectCols ...s
 
 	q := queries.Raw(exec, query, {{$pkNames | join ", "}})
 
+	{{if not .NoHooks -}}
+	if err := ({{$varNameSingular}}Query{q}).doSelectHooks(queries.GetExecutor(q)); nil != err {
+		return nil, err
+	}
+	{{- end}}
+
 	err := q.Bind({{$varNameSingular}}Obj)
 	if err != nil {
 		if errors.Cause(err) == sql.ErrNoRows {

--- a/templates/14_find.tpl
+++ b/templates/14_find.tpl
@@ -1,5 +1,6 @@
 {{- $tableNameSingular := .Table.Name | singular | titleCase -}}
 {{- $varNameSingular := .Table.Name | singular | camelCase -}}
+{{- $tableNamePlural := .Table.Name | plural | titleCase -}}
 {{- $colDefs := sqlColDefinitions .Table.Columns .Table.PKey.Columns -}}
 {{- $pkNames := $colDefs.Names | stringMap .StringFuncs.camelCase | stringMap .StringFuncs.replaceReserved -}}
 {{- $pkArgs := joinSlices " " $pkNames $colDefs.Types | join ", "}}
@@ -23,18 +24,16 @@ func Find{{$tableNameSingular}}GP({{$pkArgs}}, selectCols ...string) *{{$tableNa
 func Find{{$tableNameSingular}}(exec boil.Executor, {{$pkArgs}}, selectCols ...string) (*{{$tableNameSingular}}, error) {
 	{{$varNameSingular}}Obj := &{{$tableNameSingular}}{}
 
-	sel := "*"
-	if len(selectCols) > 0 {
-		sel = strings.Join(strmangle.IdentQuoteSlice(dialect.LQ, dialect.RQ, selectCols), ",")
-	}
-	query := fmt.Sprintf(
-		"select %s from {{.Table.Name | .SchemaTable}} where {{if .Dialect.IndexPlaceholders}}{{whereClause .LQ .RQ 1 .Table.PKey.Columns}}{{else}}{{whereClause .LQ .RQ 0 .Table.PKey.Columns}}{{end}}", sel,
+	q := {{$tableNamePlural}}(exec,
+		qm.Select(selectCols...),
+		qm.Where(
+			"{{if .Dialect.IndexPlaceholders}}{{whereClause .LQ .RQ 1 .Table.PKey.Columns}}{{else}}{{whereClause .LQ .RQ 0 .Table.PKey.Columns}}{{end}}",
+			{{$pkNames | join ", "}},
+		),
 	)
 
-	q := queries.Raw(exec, query, {{$pkNames | join ", "}})
-
 	{{if not .NoHooks -}}
-	if err := ({{$varNameSingular}}Query{q}).doSelectHooks(queries.GetExecutor(q)); nil != err {
+	if err := q.doSelectHooks(queries.GetExecutor(q.Query)); nil != err {
 		return nil, err
 	}
 	{{- end}}

--- a/templates/16_update.tpl
+++ b/templates/16_update.tpl
@@ -109,6 +109,12 @@ func (q {{$varNameSingular}}Query) UpdateAllP(cols M) {
 
 // UpdateAll updates all rows with the specified column values.
 func (q {{$varNameSingular}}Query) UpdateAll(cols M) error {
+	{{if not .NoHooks -}}
+	if err := q.doUpdateHooks(queries.GetExecutor(q.Query)); nil != err {
+		return err
+	}
+	{{end -}}
+
 	queries.SetUpdate(q.Query, cols)
 
 	_, err := q.Query.Exec()

--- a/templates/19_reload.tpl
+++ b/templates/19_reload.tpl
@@ -79,6 +79,7 @@ func (o *{{$tableNameSingular}}Slice) ReloadAll(exec boil.Executor) error {
 		args = append(args, pkeyArgs...)
 	}
 
+	// TODO: Create this via query builder to be changable by hooks
 	sql := "SELECT {{$schemaTable}}.* FROM {{$schemaTable}} WHERE " +
 		strmangle.WhereClauseRepeated(string(dialect.LQ), string(dialect.RQ), {{if .Dialect.IndexPlaceholders}}1{{else}}0{{end}}, {{$varNameSingular}}PrimaryKeyColumns, len(*o))
 

--- a/templates/19_reload.tpl
+++ b/templates/19_reload.tpl
@@ -84,6 +84,12 @@ func (o *{{$tableNameSingular}}Slice) ReloadAll(exec boil.Executor) error {
 
 	q := queries.Raw(exec, sql, args...)
 
+	{{if not .NoHooks -}}
+	if err := ({{$varNameSingular}}Query{q}).doSelectHooks(queries.GetExecutor(q)); nil != err {
+		return err
+	}
+	{{- end}}
+
 	err := q.Bind(&{{$varNamePlural}})
 	if err != nil {
 		return errors.Wrap(err, "{{.PkgName}}: unable to reload all in {{$tableNameSingular}}Slice")


### PR DESCRIPTION
I'm using sqlboiler on a database containing spatial data and wanted to retrieve raw geometry data as binary on all direct/indirect retievements (finishers, eager loads) and convert them using [go-geom](https://github.com/twpayne/go-geom).

In order to do that:
* I've changed all geometry columns translation type to []byte
* Added QueryHooks to be able to change the query before commit esp. SELECT

Now I can make my geometry column to be queried as WKB on Finishers, **Eager Loads**, Reloads and Finds by adding the query hook as below:

```go
models.AddGeoAreaQueryHook(boil.SelectHook, func (exec boil.Executor, q *queries.Query) error {
	queries.AppendSelect(q,
		fmt.Sprintf("%s.*", models.TableNames.GeoAreas),
		fmt.Sprintf("ST_AsBinary(%s) AS %s", models.GeoAreaColumns.Geometry, models.GeoAreaColumns.Geometry),
	)

	return nil
})
```

And then scanning the geometry field using go-geom/wkb or any other decoders
```go
	var mp wkb.MultiPolygon
	if err := mp.Scan(geoArea.Geometry); nil == err {
		...
	}
```