### PR TITLE
Allow ENV override for nested Viper keys

### DIFF
--- a/boilingcore/imports.go
+++ b/boilingcore/imports.go
@@ -216,6 +216,7 @@ func newImporter() importer {
 				`"math/rand"`,
 				`"os"`,
 				`"path/filepath"`,
+				`"strings"`,
 				`"testing"`,
 				`"time"`,
 			},

--- a/main.go
+++ b/main.go
@@ -34,6 +34,8 @@ func main() {
 	}
 
 	viper.SetConfigName("sqlboiler")
+	replacer := strings.NewReplacer(".", "_")
+	viper.SetEnvKeyReplacer(replacer)
 
 	configHome := os.Getenv("XDG_CONFIG_HOME")
 	homePath := os.Getenv("HOME")

--- a/templates_test/singleton/boil_main_test.tpl
+++ b/templates_test/singleton/boil_main_test.tpl
@@ -62,6 +62,8 @@ func initViper() error {
   var err error
 
 	viper.SetConfigName("sqlboiler")
+	replacer := strings.NewReplacer(".", "_")
+	viper.SetEnvKeyReplacer(replacer)
 
 	configHome := os.Getenv("XDG_CONFIG_HOME")
 	homePath := os.Getenv("HOME")


### PR DESCRIPTION
This allows me to set the following ENV variables:
```
POSTGRES_HOST
POSTGRES_DOCKER_PORT
POSTGRES_USER
POSTGRES_DBNAME
POSTGRES_PASS
POSTGRES_SSLMODE
OUTPUT
```
And not have to define a sqlboiler.yml or override XDG_CONFIG_HOME or use half-working pr #229 