### PR TITLE
Fix enum regexp to include digits

### DIFF
--- a/strmangle/strmangle.go
+++ b/strmangle/strmangle.go
@@ -17,7 +17,7 @@ var (
 	idAlphabet    = []byte("abcdefghijklmnopqrstuvwxyz")
 	smartQuoteRgx = regexp.MustCompile(`^(?i)"?[a-z_][_a-z0-9]*"?(\."?[_a-z][_a-z0-9]*"?)*(\.\*)?$`)
 
-	rgxEnum            = regexp.MustCompile(`^enum(\.[a-z_]+)?\((,?'[^']+')+\)$`)
+	rgxEnum            = regexp.MustCompile(`^enum(\.[a-z0-9_]+)?\((,?'[^']+')+\)$`)
 	rgxEnumIsOK        = regexp.MustCompile(`^(?i)[a-z][a-z0-9_]*$`)
 	rgxEnumShouldTitle = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
 )


### PR DESCRIPTION
SQLBoiler skips enum including digits (0-9) in a name (e.g. test_1).

However, enum including digits can be generated.

The following is the case of PostgreSQL.
```
testdb=# CREATE TYPE test_enum_1 AS ENUM ('test_1', 'test_2');
CREATE TYPE
```

Document: 
>SQL identifiers and key words must begin with a letter (a-z, but also letters with diacritical marks and non-Latin letters) or an underscore (_). Subsequent characters in an identifier or key word can be letters, underscores, digits (0-9), or dollar signs ($).
https://www.postgresql.org/docs/9.5/static/sql-syntax-lexical.html

Perhaps MySQL is the same.
https://dev.mysql.com/doc/refman/5.7/en/identifiers.html
>ASCII: [0-9,a-z,A-Z$_] (basic Latin letters, digits 0-9, dollar, underscore)

Thank you for the awesome tool!
