### PR TITLE
Adjust randomize/randomize.go to conform with the changes in satori/go.uuid

### DIFF
--- a/randomize/randomize.go
+++ b/randomize/randomize.go
@@ -195,7 +195,11 @@ func randomizeField(s *Seed, field reflect.Value, fieldType string, canBeNull bo
 					return nil
 				}
 				if fieldType == "uuid" {
-					value = null.NewString(uuid.NewV4().String(), true)
+					randomUuid, err := uuid.NewV4()
+					if err != nil {
+						return err
+					}
+					value = null.NewString(randomUuid.String(), true)
 					field.Set(reflect.ValueOf(value))
 					return nil
 				}
@@ -268,7 +272,10 @@ func randomizeField(s *Seed, field reflect.Value, fieldType string, canBeNull bo
 					return nil
 				}
 				if fieldType == "uuid" {
-					value = uuid.NewV4().String()
+					value, err := uuid.NewV4()
+					if err != nil {
+						return err
+					}
 					field.Set(reflect.ValueOf(value))
 					return nil
 				}
@@ -390,7 +397,11 @@ func getArrayRandValue(s *Seed, typ reflect.Type, fieldType string) interface{} 
 			return types.StringArray{value, value}
 		}
 		if fieldType == "uuid" {
-			value := uuid.NewV4().String()
+			randomUuid, err := uuid.NewV4()
+			if err != nil {
+				return err
+			}
+			value := randomUuid.String()
 			return types.StringArray{value, value}
 		}
 		if fieldType == "box" || fieldType == "line" || fieldType == "lseg" ||


### PR DESCRIPTION
satori/go.uuid changed the return signature of the New{version} function to return a value and error instead of just a single value.

The change is limited to the randomize file (as go.uuid is used nowhere else).