### PR TITLE
Support PostgreSQL citext fields

### DIFF
--- a/bdb/drivers/postgres.go
+++ b/bdb/drivers/postgres.go
@@ -348,10 +348,13 @@ func (p *PostgresDriver) TranslateColumnType(c bdb.Column) bdb.Column {
 			// Make DBType something like ARRAYinteger for parsing with randomize.Struct
 			c.DBType = c.DBType + *c.ArrType
 		case "USER-DEFINED":
-			if c.UDTName == "hstore" {
+			switch c.UDTName {
+			case "hstore":
 				c.Type = "types.HStore"
 				c.DBType = "hstore"
-			} else {
+			case "citext":
+				c.Type = "null.String"
+			default:
 				c.Type = "string"
 				fmt.Fprintf(os.Stderr, "Warning: Incompatible data type detected: %s\n", c.UDTName)
 			}
@@ -387,10 +390,13 @@ func (p *PostgresDriver) TranslateColumnType(c bdb.Column) bdb.Column {
 			// Make DBType something like ARRAYinteger for parsing with randomize.Struct
 			c.DBType = c.DBType + *c.ArrType
 		case "USER-DEFINED":
-			if c.UDTName == "hstore" {
+			switch c.UDTName {
+			case "hstore":
 				c.Type = "types.HStore"
 				c.DBType = "hstore"
-			} else {
+			case "citext":
+				c.Type = "string"
+			default:
 				c.Type = "string"
 				fmt.Printf("Warning: Incompatible data type detected: %s\n", c.UDTName)
 			}

--- a/testdata/postgres_test_schema.sql
+++ b/testdata/postgres_test_schema.sql
@@ -1,3 +1,5 @@
+CREATE EXTENSION IF NOT EXISTS citext;
+
 CREATE TYPE workday AS ENUM('monday', 'tuesday', 'wednesday', 'thursday', 'friday');
 CREATE TYPE faceyface AS ENUM('angry', 'hungry', 'bitter');
 
@@ -179,7 +181,9 @@ CREATE TABLE magic (
   iii txid_snapshot NULL,
   jjj txid_snapshot NOT NULL,
   kkk xml NULL,
-  lll xml NOT NULL
+  lll xml NOT NULL,
+  mmm citext NULL,
+  nnn citext NOT NULL
 );
 
 create table owner (


### PR DESCRIPTION
Postgres has a [citext type](https://www.postgresql.org/docs/9.1/static/citext.html) for storing textual data that you often want to perform case-insensitive operations on (e.g. usernames). It can be treated as a normal string.

Have at it! 💝 