### PR TITLE
Fix testdata Dockerfile

### DIFF
--- a/testdata/Dockerfile
+++ b/testdata/Dockerfile
@@ -4,6 +4,8 @@ FROM ubuntu:16.04
 ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/opt/mssql-tools/bin
 ENV GODIST go1.8.linux-amd64.tar.gz
 
+RUN apt-get update \
+    && apt-get -y install locales
 # Set up locales for sqlcmd (otherwise it breaks)
 RUN locale-gen en_US.UTF-8 \
     && echo "LC_ALL=en_US.UTF-8" >> /etc/default/locale \

--- a/testdata/Dockerfile
+++ b/testdata/Dockerfile
@@ -6,6 +6,7 @@ ENV GODIST go1.8.linux-amd64.tar.gz
 
 RUN apt-get update \
     && apt-get -y install locales
+
 # Set up locales for sqlcmd (otherwise it breaks)
 RUN locale-gen en_US.UTF-8 \
     && echo "LC_ALL=en_US.UTF-8" >> /etc/default/locale \


### PR DESCRIPTION
## What
Add this run command to Dockerfile
Preinstall `locales` via apt-get.

```
RUN apt-get update \
    && apt-get -y install locales
```


## Why
I try `docker build`. But got an error.

```
$ cd testdata/
$ docker build -t sqlboiler_test ./ 
```

```
Sending build context to Docker daemon  36.35kB
Step 1/8 : FROM ubuntu:16.04
 ---> 0458a4468cbc
Step 2/8 : ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/opt/mssql-tools/bin
 ---> Running in ed8c17490fbf
Removing intermediate container ed8c17490fbf
 ---> 7ba2dba729f9
Step 3/8 : ENV GODIST go1.8.linux-amd64.tar.gz
 ---> Running in afefd360f4e5
Removing intermediate container afefd360f4e5
 ---> a195eb5f25ef
Step 4/8 : RUN locale-gen en_US.UTF-8     && echo "LC_ALL=en_US.UTF-8" >> /etc/default/locale     && echo "LANG=en_US.UTF-8" >> /etc/default/locale
 ---> Running in 50e3756f683b
/bin/sh: 1: locale-gen: not found
The command '/bin/sh -c locale-gen en_US.UTF-8     && echo "LC_ALL=en_US.UTF-8" >> /etc/default/locale     && echo "LANG=en_US.UTF-8" >> /etc/default/locale' returned a non-zero code: 127
```
