### PR TITLE
fix strmangle tests

### DIFF
--- a/strmangle/strmangle_test.go
+++ b/strmangle/strmangle_test.go
@@ -596,9 +596,9 @@ func TestReplaceReservedWords(t *testing.T) {
 	for i, test := range tests {
 		got := ReplaceReservedWords(test.Word)
 		if test.Replace && !strings.HasSuffix(got, "_") {
-			t.Errorf("%i) want suffixed (%s), got: %s", i, test.Word, got)
+			t.Errorf("%v) want suffixed (%s), got: %s", i, test.Word, got)
 		} else if !test.Replace && strings.HasSuffix(got, "_") {
-			t.Errorf("%i) want normal (%s), got: %s", i, test.Word, got)
+			t.Errorf("%v) want normal (%s), got: %s", i, test.Word, got)
 		}
 	}
 }


### PR DESCRIPTION
I found that the unit tests were failing due to a typo where %i was in the fmt string instead of %d. Now all unit tests pass.