### PR TITLE
[#296] - swap order of range to ensure all foreign references are set properly

### DIFF
--- a/templates/09_relationship_to_many_eager.tpl
+++ b/templates/09_relationship_to_many_eager.tpl
@@ -116,8 +116,8 @@ func ({{$varNameSingular}}L) Load{{$txt.Function.Name}}(e boil.Executor, singula
 		}
 	}
 	{{else -}}
-	for _, foreign := range resultSlice {
-		for _, local := range slice {
+	for _, local := range slice {
+		for _, foreign := range resultSlice {
 			{{if $txt.Function.UsesBytes -}}
 			if 0 == bytes.Compare(local.{{$txt.Function.LocalAssignment}}, foreign.{{$txt.Function.ForeignAssignment}}) {
 			{{else -}}


### PR DESCRIPTION
By changing the order of range loops, the values are set correctly if less rows are returned from the SQL query.