### PR TITLE
Use string rather than []byte for types.JSON

### DIFF
--- a/types/json.go
+++ b/types/json.go
@@ -55,7 +55,10 @@ func (j JSON) Value() (driver.Value, error) {
 		return nil, err
 	}
 
-	return []byte(r), nil
+	// must use string rather than []byte as MySQL treats []byte as binary but
+	// doesn't allow binary types to be inserted into JSON columns due to the lack
+	// of explicit character encoding information.
+	return string(r), nil
 }
 
 // Scan stores the src in *j.


### PR DESCRIPTION
This fixes an issue with MySQL that doesn't accept []byte (mapped to binary in MySQL) as a valid type for JSON columns due to the lack of character encoding information.

Ideally, the Golang SQL driver should have an explicit JSON type so that this can be pushed down to the drivers to handle. However, sadly the driver interface doesn't support this and we must collapse to either `[]byte` or `string`. I believe `string` should work across all databases for JSON.