### PR TITLE
Fix generation of nullable JSON type for MySQL

### DIFF
--- a/bdb/drivers/mysql.go
+++ b/bdb/drivers/mysql.go
@@ -319,7 +319,7 @@ func (m *MySQLDriver) TranslateColumnType(c bdb.Column) bdb.Column {
 		case "binary", "varbinary", "tinyblob", "blob", "mediumblob", "longblob":
 			c.Type = "null.Bytes"
 		case "json":
-			c.Type = "types.JSON"
+			c.Type = "null.JSON"
 		default:
 			c.Type = "null.String"
 		}


### PR DESCRIPTION
- A nullable JSON field was being generated as types.JSON
  for MySQL
- This fix changes the generation to be null.JSON

https://github.com/volatiletech/sqlboiler/issues/311