### PR TITLE
fix random time issue in test

### DIFF
--- a/randomize/random.go
+++ b/randomize/random.go
@@ -90,6 +90,10 @@ func randMoney(s *Seed) string {
 	return fmt.Sprintf("%d.00", s.nextInt())
 }
 
+func randTime() string {
+	return fmt.Sprintf("%d:%d:%d", rand.Intn(24), rand.Intn(60), rand.Intn(60))
+}
+
 // StableDBName takes a database name in, and generates
 // a random string using the database name as the rand Seed.
 // getDBNameHash is used to generate unique test database names.

--- a/randomize/randomize.go
+++ b/randomize/randomize.go
@@ -55,7 +55,7 @@ var (
 		"inet", "line", "uuid", "interval", "mediumint",
 		"json", "jsonb", "box", "cidr", "circle",
 		"lseg", "macaddr", "path", "pg_lsn", "point",
-		"polygon", "txid_snapshot", "money", "hstore",
+		"polygon", "txid_snapshot", "money", "time", "hstore",
 	}
 )
 
@@ -244,6 +244,11 @@ func randomizeField(s *Seed, field reflect.Value, fieldType string, canBeNull bo
 					field.Set(reflect.ValueOf(value))
 					return nil
 				}
+				if fieldType == "time" {
+					value = null.NewString(randTime(), true)
+					field.Set(reflect.ValueOf(value))
+					return nil
+				}
 			case typeNullInt32:
 				if fieldType == "mediumint" {
 					// 8388607 is the max for 3 byte int
@@ -317,6 +322,11 @@ func randomizeField(s *Seed, field reflect.Value, fieldType string, canBeNull bo
 				}
 				if fieldType == "money" {
 					value = randMoney(s)
+					field.Set(reflect.ValueOf(value))
+					return nil
+				}
+				if fieldType == "time" {
+					value = randTime()
 					field.Set(reflect.ValueOf(value))
 					return nil
 				}


### PR DESCRIPTION
After #221

Mysql type TIME is scanned as `string`
But test will fail if random `TIME` as general string.

I can also port this fix to **v3** later.