### PR TITLE
Allow empty pass in drivers

### DIFF
--- a/drivers/sqlboiler-mssql/driver/mssql.go
+++ b/drivers/sqlboiler-mssql/driver/mssql.go
@@ -61,7 +61,7 @@ func (m *MSSQLDriver) Assemble(config drivers.Config) (dbinfo *drivers.DBInfo, e
 	}()
 
 	user := config.MustString(drivers.ConfigUser)
-	pass := config.MustString(drivers.ConfigPass)
+	pass, _ := config.String(drivers.ConfigPass)
 	dbname := config.MustString(drivers.ConfigDBName)
 	host := config.MustString(drivers.ConfigHost)
 	port := config.DefaultInt(drivers.ConfigPort, 1433)

--- a/drivers/sqlboiler-mysql/driver/mysql.go
+++ b/drivers/sqlboiler-mysql/driver/mysql.go
@@ -61,7 +61,7 @@ func (m *MySQLDriver) Assemble(config drivers.Config) (dbinfo *drivers.DBInfo, e
 	}()
 
 	user := config.MustString(drivers.ConfigUser)
-	pass := config.MustString(drivers.ConfigPass)
+	pass, _ := config.String(drivers.ConfigPass)
 	dbname := config.MustString(drivers.ConfigDBName)
 	host := config.MustString(drivers.ConfigHost)
 	port := config.DefaultInt(drivers.ConfigPort, 3306)

--- a/drivers/sqlboiler-psql/driver/psql.go
+++ b/drivers/sqlboiler-psql/driver/psql.go
@@ -66,7 +66,7 @@ func (p *PostgresDriver) Assemble(config drivers.Config) (dbinfo *drivers.DBInfo
 	}()
 
 	user := config.MustString(drivers.ConfigUser)
-	pass := config.MustString(drivers.ConfigPass)
+	pass, _ := config.String(drivers.ConfigPass)
 	dbname := config.MustString(drivers.ConfigDBName)
 	host := config.MustString(drivers.ConfigHost)
 	port := config.DefaultInt(drivers.ConfigPort, 5432)


### PR DESCRIPTION
sqlboiler v3's README describes that the pass is an optional parameter.
But current implementation does not allow an empty pass.