### PR TITLE
Add import for nullable JSON fields in MySQL

### DIFF
--- a/drivers/sqlboiler-mysql/driver/mysql.go
+++ b/drivers/sqlboiler-mysql/driver/mysql.go
@@ -553,6 +553,9 @@ func (MySQLDriver) Imports() (col importers.Collection, err error) {
 		"null.Bytes": {
 			ThirdParty: importers.List{`"github.com/volatiletech/null"`},
 		},
+		"null.JSON": {
+			ThirdParty: importers.List{`"github.com/volatiletech/null"`},
+		},
 
 		"time.Time": {
 			Standard: importers.List{`"time"`},


### PR DESCRIPTION
Fixes a possible regression from #311. Before this fix, generated models with nullable JSON columns are missing the import for `null`.