### PR TITLE
Fix: `panic: assignment to entry in nil map`

### DIFF
--- a/boilingcore/aliases.go
+++ b/boilingcore/aliases.go
@@ -42,8 +42,11 @@ func FillAliases(a *Aliases, tables []drivers.Table) {
 
 	for _, t := range tables {
 		if t.IsJoinTable {
-			if _, ok := a.Tables[t.Name]; !ok  || a.Tables[t.Name].Relationships == nil {
+			jt, ok := a.Tables[t.Name];
+			if !ok {
 				a.Tables[t.Name] = TableAlias{Relationships: make(map[string]RelationshipAlias)}
+			} else if jt.Relationships == nil {
+				jt.Relationships = make(map[string]RelationshipAlias)
 			}
 			continue
 		}

--- a/boilingcore/aliases.go
+++ b/boilingcore/aliases.go
@@ -42,7 +42,7 @@ func FillAliases(a *Aliases, tables []drivers.Table) {
 
 	for _, t := range tables {
 		if t.IsJoinTable {
-			if _, ok := a.Tables[t.Name]; !ok {
+			if _, ok := a.Tables[t.Name]; !ok  || a.Tables[t.Name].Relationships == nil {
 				a.Tables[t.Name] = TableAlias{Relationships: make(map[string]RelationshipAlias)}
 			}
 			continue


### PR DESCRIPTION
```
panic: assignment to entry in nil map

goroutine 1 [running]:
github.com/volatiletech/sqlboiler/boilingcore.FillAliases(0xc04215e9d8, 0xc04229c000, 0x8, 0x9)
	C:/Users/veres/go/src/github.com/volatiletech/sqlboiler/boilingcore/aliases.go:154 +0x1274
```

For existing tables the Relationships is not getting initialized, hence a join table runs into a nil map problem