### PR TITLE
Issue #405 - Fixed MySQL column ordering when building model

### DIFF
--- a/drivers/sqlboiler-mysql/driver/mysql.go
+++ b/drivers/sqlboiler-mysql/driver/mysql.go
@@ -202,7 +202,8 @@ func (m *MySQLDriver) Columns(schema, tableName string, whitelist, blacklist []s
 				(select count(*) from information_schema.key_column_usage where table_schema = kcu.table_schema and table_name = tc.table_name and constraint_name = tc.constraint_name) = 1
 		) as is_unique
 	from information_schema.columns as c
-	where table_name = ? and table_schema = ? and c.extra not like '%VIRTUAL%'`
+	where table_name = ? and table_schema = ? and c.extra not like '%VIRTUAL%'
+	order by c.ordinal_position`
 
 	if len(whitelist) > 0 {
 		cols := drivers.ColumnsFromList(whitelist, tableName)


### PR DESCRIPTION
https://dev.mysql.com/doc/refman/8.0/en/columns-table.html indicates that selecting from the columns table has no guarantee of column order. In my case, I was getting the columns back (sometimes) in alphabetical order instead of the order they appeared in the table.