### PR TITLE
add err check after rows.Next() in bind function

### DIFF
--- a/queries/reflect.go
+++ b/queries/reflect.go
@@ -288,6 +288,9 @@ Rows:
 			ptrSlice.Set(reflect.Append(ptrSlice, newStruct))
 		}
 	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
 
 	if bkind == kindStruct && !foundOne {
 		return sql.ErrNoRows


### PR DESCRIPTION
Add err check after rows.Next() in bind function, like the example of `QueryContext`.
Some sql errors will be ignored in previous version.

```go
	rows, err := db.QueryContext(ctx, "SELECT name FROM users WHERE age=?", age)
	if err != nil {
		log.Fatal(err)
	}
	defer rows.Close()
	names := make([]string, 0)
	for rows.Next() {
		var name string
		if err := rows.Scan(&name); err != nil {
			log.Fatal(err)
		}
		names = append(names, name)
	}
	if err := rows.Err(); err != nil {
		log.Fatal(err)
	}
```
https://golang.org/pkg/database/sql/#DB.QueryContext