### PR TITLE
Add note to readme for mysql ssl-mode option requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ fmt.Println(len(users.R.FavoriteMovies))
   `user_videos` you should have: `primary key(user_id, video_id)`, with both
   `user_id` and `video_id` being foreign key columns to the users and videos
   tables respectively and there are no other columns on this table.
+* MySQL 5.6.30 minimum; ssl-mode option is not supported for earlier versions.
 * For MySQL if using the `github.com/go-sql-driver/mysql` driver, please activate
   [time.Time parsing](https://github.com/go-sql-driver/mysql#timetime-support) when making your
   MySQL database connection. SQLBoiler uses `time.Time` and `null.Time` to represent time in


### PR DESCRIPTION
I just ran into this issue https://github.com/volatiletech/sqlboiler/issues/117, but with MySQL 5.5.

SSL mode was introduced in 5.6.30 according to https://dev.mysql.com/doc/refman/5.6/en/encrypted-connection-options.html

I thought I'd add a note in the README calling out this requirement