### PR TITLE
Set \'1=0` when args is empty on WhereIn clause

### DIFF
--- a/queries/query_builders.go
+++ b/queries/query_builders.go
@@ -350,6 +350,11 @@ ManualParen:
 			buf.WriteByte(')')
 		case whereKindIn:
 			ln := len(where.args)
+			if ln == 0 {
+				buf.WriteString("1=0")
+				continue
+			}
+
 			matches := rgxInClause.FindStringSubmatch(where.clause)
 			// If we can't find any matches attempt a simple replace with 1 group.
 			// Clauses that fit this criteria will not be able to contain ? in their

--- a/queries/query_builders_test.go
+++ b/queries/query_builders_test.go
@@ -310,7 +310,7 @@ func TestInClause(t *testing.T) {
 			q: Query{
 				where: []where{{kind: whereKindIn, clause: "a in ?", args: []interface{}{}, orSeparator: true}},
 			},
-			expect: ` WHERE ("a" IN ())`,
+			expect: ` WHERE 1=0`,
 		},
 		{
 			q: Query{


### PR DESCRIPTION
`WHERE ("a" IN ())` causes syntax error in postgresql.
in activerecord of rails/rails, it inserts `1=0` instead of empty IN clause when args is empty 

discusion: https://github.com/rails/rails/pull/9216
code https://github.com/rails/rails/blob/v5.2.3/activerecord/lib/active_record/relation/predicate_builder.rb#L69