### PR TITLE
Use new go-sqlmock import path

### DIFF
--- a/queries/reflect_test.go
+++ b/queries/reflect_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/volatiletech/sqlboiler/drivers"
 
-	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+	"github.com/DATA-DOG/go-sqlmock"
 )
 
 func bin64(i uint64) string {


### PR DESCRIPTION
Fixes #553.

The canonical/recommended import path for sqlmock has changed. Using the correct path makes the Go compiler happy in module mode.

```
$ go test ./queries                  
ok  	github.com/volatiletech/sqlboiler/queries	0.004s
```

Opened PR to the `dev` branch, as per the contributing docs.