### PR TITLE
Remove periodicitly from picking string

### DIFF
--- a/randomize/random.go
+++ b/randomize/random.go
@@ -19,7 +19,7 @@ const alphabetLowerAlpha = "abcdefghijklmnopqrstuvwxyz"
 func Str(nextInt func() int64, ln int) string {
 	str := make([]byte, ln)
 	for i := 0; i < ln; i++ {
-		str[i] = byte(alphabetAll[nextInt()%int64(len(alphabetAll))])
+		str[i] = byte(alphabetAll[rand.Intn(len(alphabetAll))])
 	}
 
 	return string(str)

--- a/randomize/randomize.go
+++ b/randomize/randomize.go
@@ -276,7 +276,7 @@ func getVariableRandValue(s *Seed, fieldType string, kind reflect.Kind, typ refl
 		if ok {
 			return str
 		}
-		return Str(s.NextInt, 1)
+		return Str(s.NextInt, 2)
 	case reflect.Slice:
 		sliceVal := typ.Elem()
 		if sliceVal.Kind() != reflect.Uint8 {


### PR DESCRIPTION
This change may good effect to #277

In case define 1-many relationship table and child table has multiple varchar column, value of one of unique column are get duplicated.

```sql
CREATE TABLE `parents` (
  `id` INT NOT NULL AUTO_INCREMENT
)

CREATE TABLE `childs` (
  `id` INT NOT NULL AUTO_INCREMENT,
  `parent_id` INT NOT NULL,
  `foo` VARCHAR(255) NOT NULL,
  `bar` VARCHAR(255) NOT NULL,
  PRIMARY KEY (`id`),
  UNIQUE KEY `idx_foo` (`foo`),
  KEY `parent_id_idx` (`parent_id`),
  CONSTRAINT `ibfk` FOREIGN KEY (`parent_id`) REFERENCES `parents` (`id`)
)
```
generated test named `testParentToManyAddOpChilds` will fail like `Duplicate entry 'k' for key 'idx_foo'`

because the value set to VARCHAR column has periodicity.
```
b.Foo: "K"
c.Foo: "W"
d.Foo: "8"
e.Foo: "k"   # <= duplicated
seed: 1562208263
```
OR
```
b.Foo: "G"
c.Foo: "s"
d.Foo: "4"
e.Foo: "g"   # <= duplicated
seed: 1562208755
```
and so on...

Pick a random positions of word is enough to avoid this collision instead of using `nextInt()`.