### PR TITLE
Conditionally disable parsing of templates provided by the driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ not to pass them through the command line or environment variables:
 | no-tests            | false     |
 | no-auto-timestamps  | false     |
 | no-rows-affected    | false     |
+| no-driver-templates | false     |
 
 Example:
 

--- a/boilingcore/boilingcore.go
+++ b/boilingcore/boilingcore.go
@@ -133,23 +133,24 @@ func New(config *Config) (*State, error) {
 // state given.
 func (s *State) Run() error {
 	data := &templateData{
-		Tables:           s.Tables,
-		Aliases:          s.Config.Aliases,
-		DriverName:       s.Config.DriverName,
-		PkgName:          s.Config.PkgName,
-		AddGlobal:        s.Config.AddGlobal,
-		AddPanic:         s.Config.AddPanic,
-		NoContext:        s.Config.NoContext,
-		NoHooks:          s.Config.NoHooks,
-		NoAutoTimestamps: s.Config.NoAutoTimestamps,
-		NoRowsAffected:   s.Config.NoRowsAffected,
-		StructTagCasing:  s.Config.StructTagCasing,
-		Tags:             s.Config.Tags,
-		Dialect:          s.Dialect,
-		Schema:           s.Schema,
-		LQ:               strmangle.QuoteCharacter(s.Dialect.LQ),
-		RQ:               strmangle.QuoteCharacter(s.Dialect.RQ),
-		OutputDirDepth:   s.Config.OutputDirDepth(),
+		Tables:            s.Tables,
+		Aliases:           s.Config.Aliases,
+		DriverName:        s.Config.DriverName,
+		PkgName:           s.Config.PkgName,
+		AddGlobal:         s.Config.AddGlobal,
+		AddPanic:          s.Config.AddPanic,
+		NoContext:         s.Config.NoContext,
+		NoHooks:           s.Config.NoHooks,
+		NoAutoTimestamps:  s.Config.NoAutoTimestamps,
+		NoRowsAffected:    s.Config.NoRowsAffected,
+		NoDriverTemplates: s.Config.NoDriverTemplates,
+		StructTagCasing:   s.Config.StructTagCasing,
+		Tags:              s.Config.Tags,
+		Dialect:           s.Dialect,
+		Schema:            s.Schema,
+		LQ:                strmangle.QuoteCharacter(s.Dialect.LQ),
+		RQ:                strmangle.QuoteCharacter(s.Dialect.RQ),
+		OutputDirDepth:    s.Config.OutputDirDepth(),
 
 		DBTypes:     make(once),
 		StringFuncs: templateStringMappers,
@@ -238,13 +239,15 @@ func (s *State) initTemplates() ([]lazyTemplate, error) {
 		}
 	}
 
-	driverTemplates, err := s.Driver.Templates()
-	if err != nil {
-		return nil, err
-	}
+	if !s.Config.NoDriverTemplates {
+		driverTemplates, err := s.Driver.Templates()
+		if err != nil {
+			return nil, err
+		}
 
-	for template, contents := range driverTemplates {
-		templates[normalizeSlashes(template)] = base64Loader(contents)
+		for template, contents := range driverTemplates {
+			templates[normalizeSlashes(template)] = base64Loader(contents)
+		}
 	}
 
 	for _, replace := range s.Config.Replacements {

--- a/boilingcore/config.go
+++ b/boilingcore/config.go
@@ -14,21 +14,22 @@ type Config struct {
 	DriverName   string         `toml:"driver_name,omitempty" json:"driver_name,omitempty"`
 	DriverConfig drivers.Config `toml:"driver_config,omitempty" json:"driver_config,omitempty"`
 
-	PkgName          string   `toml:"pkg_name,omitempty" json:"pkg_name,omitempty"`
-	OutFolder        string   `toml:"out_folder,omitempty" json:"out_folder,omitempty"`
-	TemplateDirs     []string `toml:"template_dirs,omitempty" json:"template_dirs,omitempty"`
-	Tags             []string `toml:"tags,omitempty" json:"tags,omitempty"`
-	Replacements     []string `toml:"replacements,omitempty" json:"replacements,omitempty"`
-	Debug            bool     `toml:"debug,omitempty" json:"debug,omitempty"`
-	AddGlobal        bool     `toml:"add_global,omitempty" json:"add_global,omitempty"`
-	AddPanic         bool     `toml:"add_panic,omitempty" json:"add_panic,omitempty"`
-	NoContext        bool     `toml:"no_context,omitempty" json:"no_context,omitempty"`
-	NoTests          bool     `toml:"no_tests,omitempty" json:"no_tests,omitempty"`
-	NoHooks          bool     `toml:"no_hooks,omitempty" json:"no_hooks,omitempty"`
-	NoAutoTimestamps bool     `toml:"no_auto_timestamps,omitempty" json:"no_auto_timestamps,omitempty"`
-	NoRowsAffected   bool     `toml:"no_rows_affected,omitempty" json:"no_rows_affected,omitempty"`
-	Wipe             bool     `toml:"wipe,omitempty" json:"wipe,omitempty"`
-	StructTagCasing  string   `toml:"struct_tag_casing,omitempty" json:"struct_tag_casing,omitempty"`
+	PkgName           string   `toml:"pkg_name,omitempty" json:"pkg_name,omitempty"`
+	OutFolder         string   `toml:"out_folder,omitempty" json:"out_folder,omitempty"`
+	TemplateDirs      []string `toml:"template_dirs,omitempty" json:"template_dirs,omitempty"`
+	Tags              []string `toml:"tags,omitempty" json:"tags,omitempty"`
+	Replacements      []string `toml:"replacements,omitempty" json:"replacements,omitempty"`
+	Debug             bool     `toml:"debug,omitempty" json:"debug,omitempty"`
+	AddGlobal         bool     `toml:"add_global,omitempty" json:"add_global,omitempty"`
+	AddPanic          bool     `toml:"add_panic,omitempty" json:"add_panic,omitempty"`
+	NoContext         bool     `toml:"no_context,omitempty" json:"no_context,omitempty"`
+	NoTests           bool     `toml:"no_tests,omitempty" json:"no_tests,omitempty"`
+	NoHooks           bool     `toml:"no_hooks,omitempty" json:"no_hooks,omitempty"`
+	NoAutoTimestamps  bool     `toml:"no_auto_timestamps,omitempty" json:"no_auto_timestamps,omitempty"`
+	NoRowsAffected    bool     `toml:"no_rows_affected,omitempty" json:"no_rows_affected,omitempty"`
+	NoDriverTemplates bool     `toml:"no_driver_templates,omitempty" json:"no_driver_templates,omitempty"`
+	Wipe              bool     `toml:"wipe,omitempty" json:"wipe,omitempty"`
+	StructTagCasing   string   `toml:"struct_tag_casing,omitempty" json:"struct_tag_casing,omitempty"`
 
 	Imports importers.Collection `toml:"imports,omitempty" json:"imports,omitempty"`
 

--- a/boilingcore/templates.go
+++ b/boilingcore/templates.go
@@ -37,12 +37,13 @@ type templateData struct {
 	RQ string
 
 	// Control various generation features
-	AddGlobal        bool
-	AddPanic         bool
-	NoContext        bool
-	NoHooks          bool
-	NoAutoTimestamps bool
-	NoRowsAffected   bool
+	AddGlobal         bool
+	AddPanic          bool
+	NoContext         bool
+	NoHooks           bool
+	NoAutoTimestamps  bool
+	NoRowsAffected    bool
+	NoDriverTemplates bool
 
 	// Tags control which tags are added to the struct
 	Tags []string

--- a/main.go
+++ b/main.go
@@ -101,6 +101,7 @@ func main() {
 	rootCmd.PersistentFlags().BoolP("no-hooks", "", false, "Disable hooks feature for your models")
 	rootCmd.PersistentFlags().BoolP("no-rows-affected", "", false, "Disable rows affected in the generated API")
 	rootCmd.PersistentFlags().BoolP("no-auto-timestamps", "", false, "Disable automatic timestamps for created_at/updated_at")
+	rootCmd.PersistentFlags().BoolP("no-driver-templates", "", false, "Disable parsing of templates defined by the database driver")
 	rootCmd.PersistentFlags().BoolP("add-global-variants", "", false, "Enable generation for global variants")
 	rootCmd.PersistentFlags().BoolP("add-panic-variants", "", false, "Enable generation for panic variants")
 	rootCmd.PersistentFlags().BoolP("version", "", false, "Print the version")
@@ -161,25 +162,26 @@ func preRun(cmd *cobra.Command, args []string) error {
 	drivers.RegisterBinary(driverName, driverPath)
 
 	cmdConfig = &boilingcore.Config{
-		DriverName:       driverName,
-		OutFolder:        viper.GetString("output"),
-		PkgName:          viper.GetString("pkgname"),
-		Debug:            viper.GetBool("debug"),
-		AddGlobal:        viper.GetBool("add-global-variants"),
-		AddPanic:         viper.GetBool("add-panic-variants"),
-		NoContext:        viper.GetBool("no-context"),
-		NoTests:          viper.GetBool("no-tests"),
-		NoHooks:          viper.GetBool("no-hooks"),
-		NoRowsAffected:   viper.GetBool("no-rows-affected"),
-		NoAutoTimestamps: viper.GetBool("no-auto-timestamps"),
-		Wipe:             viper.GetBool("wipe"),
-		StructTagCasing:  strings.ToLower(viper.GetString("struct-tag-casing")), // camel | snake | title
-		TemplateDirs:     viper.GetStringSlice("templates"),
-		Tags:             viper.GetStringSlice("tag"),
-		Replacements:     viper.GetStringSlice("replace"),
-		Aliases:          boilingcore.ConvertAliases(viper.Get("aliases")),
-		TypeReplaces:     boilingcore.ConvertTypeReplace(viper.Get("types")),
-		Version:          sqlBoilerVersion,
+		DriverName:        driverName,
+		OutFolder:         viper.GetString("output"),
+		PkgName:           viper.GetString("pkgname"),
+		Debug:             viper.GetBool("debug"),
+		AddGlobal:         viper.GetBool("add-global-variants"),
+		AddPanic:          viper.GetBool("add-panic-variants"),
+		NoContext:         viper.GetBool("no-context"),
+		NoTests:           viper.GetBool("no-tests"),
+		NoHooks:           viper.GetBool("no-hooks"),
+		NoRowsAffected:    viper.GetBool("no-rows-affected"),
+		NoAutoTimestamps:  viper.GetBool("no-auto-timestamps"),
+		NoDriverTemplates: viper.GetBool("no-driver-templates"),
+		Wipe:              viper.GetBool("wipe"),
+		StructTagCasing:   strings.ToLower(viper.GetString("struct-tag-casing")), // camel | snake | title
+		TemplateDirs:      viper.GetStringSlice("templates"),
+		Tags:              viper.GetStringSlice("tag"),
+		Replacements:      viper.GetStringSlice("replace"),
+		Aliases:           boilingcore.ConvertAliases(viper.Get("aliases")),
+		TypeReplaces:      boilingcore.ConvertTypeReplace(viper.Get("types")),
+		Version:           sqlBoilerVersion,
 	}
 
 	if cmdConfig.Debug {


### PR DESCRIPTION
For the case when templates for a language other than Go are generated, it is useful to have a configuration parameter that stops templates provided by the driver from being parsed. 

For example, I want to generate a very simple data structure in TypeScript for the front-end of my webapp. The template is as follows (adapted from Go template):
```
// 00_class.ts.tpl
{{- $alias := .Aliases.Table .Table.Name -}}

export default class {{$alias.UpSingular}}Model {
{{range $column := .Table.Columns}}
    public {{$column.Name}};
{{- end }}
}
```

Without the proposed changes, I cannot complete the generation of the class because a driver template throws the following error when running `sqlboiler psql`: 
```
Error: unable to generate output: failed to execute template: templates\17_upsert.go.tpl: template: templates\17_upsert.go.tpl:39:14: executing "templates\\17_upsert.go.tpl" at <{{template "timestamp_upsert_helper" .}}>: template "timestamp_upsert_helper" not defined
```

For my use case it makes sense to use the psql driver, but having it also output go files in a typescript project is a pointless effort.
