### PR TITLE
Sample fix for issue 404

### DIFF
--- a/types/decimal.go
+++ b/types/decimal.go
@@ -28,6 +28,13 @@ type NullDecimal struct {
 	*decimal.Big
 }
 
+func (d *NullDecimal) UnmarshalJSON(data []byte) error {
+	if d.Big == nil {
+		d.Big = new(decimal.Big)
+	}
+	return d.Big.UnmarshalJSON(data)
+}
+
 // NewDecimal creates a new decimal from a decimal
 func NewDecimal(d *decimal.Big) Decimal {
 	return Decimal{Big: d}

--- a/types/decimal_test.go
+++ b/types/decimal_test.go
@@ -6,6 +6,28 @@ import (
 	"github.com/ericlagergren/decimal"
 )
 
+func TestIssue404(t *testing.T) {
+	testPanic := func(t *testing.T, fn func(t *testing.T)) (panicked bool) {
+		defer func() {
+			if recover() != nil {
+				panicked = true
+			}
+		}()
+		fn(t)
+		return panicked
+	}
+	panicked := testPanic(t, func(t *testing.T) {
+		var d NullDecimal
+		err := d.UnmarshalJSON([]byte("3.14"))
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+	if panicked {
+		t.Fatal("unexpected panic")
+	}
+}
+
 func TestDecimal_Value(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
I noticed somebody else ran into this snag, so I decided it might be a good idea to re-look at the problem.

Unfortunately, there's not much I can do on my end. There are trade offs between what other packages do:

```
type T { x *big.Int }
func (x T) Add(y T) T { ... }
````

and what my package does:

```
type T { x big.Int }
func (z *T) Add(x, y *T) *T { ... }
```

One of these is the inability to unmarshal into a nil pointer.

So, this is just an example of one way to fix the problem. I'm sure there are others. But if this is continuing to affect folks like in https://github.com/ericlagergren/decimal/issues/141, it might be good to re-open the conversation.