### PR TITLE
Make port configurable via env by parse string to int

### DIFF
--- a/drivers/config.go
+++ b/drivers/config.go
@@ -47,7 +47,11 @@ func (c Config) MustInt(key string) int {
 	case float64:
 		integer = int(t)
 	case string:
-		integer, _ = strconv.Atoi(t)
+		var err error
+		integer, err = strconv.Atoi(t)
+		if err != nil {
+			panic(errors.Errorf("fail to parse %v to int: %v", t, err))
+		}
 	default:
 		panic(errors.Errorf("found key %s in config, but it was not an int (%T)", key, i))
 	}
@@ -104,7 +108,11 @@ func (c Config) Int(key string) (int, bool) {
 	case float64:
 		integer = int(t)
 	case string:
-		integer, _ = strconv.Atoi(t)
+		var err error
+		integer, err = strconv.Atoi(t)
+		if err != nil {
+			return 0, false
+		}
 	default:
 		return 0, false
 	}

--- a/drivers/config.go
+++ b/drivers/config.go
@@ -5,6 +5,7 @@ package drivers
 
 import (
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -45,6 +46,8 @@ func (c Config) MustInt(key string) int {
 		integer = t
 	case float64:
 		integer = int(t)
+	case string:
+		integer, _ = strconv.Atoi(t)
 	default:
 		panic(errors.Errorf("found key %s in config, but it was not an int (%T)", key, i))
 	}
@@ -100,6 +103,8 @@ func (c Config) Int(key string) (int, bool) {
 		integer = t
 	case float64:
 		integer = int(t)
+	case string:
+		integer, _ = strconv.Atoi(t)
 	default:
 		return 0, false
 	}


### PR DESCRIPTION
Before this commit, following bash script won't work

```
  PSQL_DBNAME="postgres" \
    PSQL_HOST="localhost" \
    PSQL_PORT="11432" \
    PSQL_USER="postgres" \
    PSQL_PASS='' \
    PSQL_SCHEMA="$schema" \
    PSQL_SSLMODE="disable" \
    sqlboiler --wipe --no-tests -o "internal/model/db/$schema" -p "$schema" \
    --templates ./templates/sqlboiler/ psql
```

`PSQL_PORT` is passed correctly, but failed to parse due to its string type. sqlboiler use default port 5432, which is undesired result.

This commit fix that.