### PR TITLE
Add support for go 1.13 errors

### DIFF
--- a/boilingcore/boilingcore.go
+++ b/boilingcore/boilingcore.go
@@ -11,7 +11,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/pkg/errors"
+	"github.com/friendsofgo/errors"
 	"github.com/volatiletech/sqlboiler/drivers"
 	"github.com/volatiletech/sqlboiler/importers"
 	"github.com/volatiletech/sqlboiler/strmangle"

--- a/boilingcore/output.go
+++ b/boilingcore/output.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/pkg/errors"
+	"github.com/friendsofgo/errors"
 	"github.com/volatiletech/sqlboiler/importers"
 )
 

--- a/boilingcore/templates.go
+++ b/boilingcore/templates.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/pkg/errors"
+	"github.com/friendsofgo/errors"
 	"github.com/volatiletech/sqlboiler/drivers"
 	"github.com/volatiletech/sqlboiler/strmangle"
 	"github.com/volatiletech/sqlboiler/templatebin"

--- a/drivers/binary_driver.go
+++ b/drivers/binary_driver.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/pkg/errors"
+	"github.com/friendsofgo/errors"
 	"github.com/volatiletech/sqlboiler/importers"
 )
 

--- a/drivers/config.go
+++ b/drivers/config.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/pkg/errors"
+	"github.com/friendsofgo/errors"
 )
 
 // Config is a map with helper functions

--- a/drivers/interface.go
+++ b/drivers/interface.go
@@ -5,7 +5,7 @@ package drivers
 import (
 	"sort"
 
-	"github.com/pkg/errors"
+	"github.com/friendsofgo/errors"
 	"github.com/volatiletech/sqlboiler/importers"
 	"github.com/volatiletech/sqlboiler/strmangle"
 )

--- a/drivers/sqlboiler-mssql/driver/bindata.go
+++ b/drivers/sqlboiler-mssql/driver/bindata.go
@@ -264,15 +264,11 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"templates/17_upsert.go.tpl": templates17_upsertGoTpl,
-
-	"templates/singleton/mssql_upsert.go.tpl": templatesSingletonMssql_upsertGoTpl,
-
-	"templates_test/singleton/mssql_main_test.go.tpl": templates_testSingletonMssql_main_testGoTpl,
-
+	"templates/17_upsert.go.tpl":                        templates17_upsertGoTpl,
+	"templates/singleton/mssql_upsert.go.tpl":           templatesSingletonMssql_upsertGoTpl,
+	"templates_test/singleton/mssql_main_test.go.tpl":   templates_testSingletonMssql_main_testGoTpl,
 	"templates_test/singleton/mssql_suites_test.go.tpl": templates_testSingletonMssql_suites_testGoTpl,
-
-	"templates_test/upsert.go.tpl": templates_testUpsertGoTpl,
+	"templates_test/upsert.go.tpl":                      templates_testUpsertGoTpl,
 }
 
 // AssetDir returns the file names below a certain

--- a/drivers/sqlboiler-mssql/driver/mssql.go
+++ b/drivers/sqlboiler-mssql/driver/mssql.go
@@ -9,7 +9,7 @@ import (
 
 	// Side effect import go-mssqldb
 	_ "github.com/denisenkom/go-mssqldb"
-	"github.com/pkg/errors"
+	"github.com/friendsofgo/errors"
 	"github.com/volatiletech/sqlboiler/drivers"
 	"github.com/volatiletech/sqlboiler/importers"
 	"github.com/volatiletech/sqlboiler/strmangle"
@@ -486,7 +486,7 @@ func (MSSQLDriver) Imports() (col importers.Collection, err error) {
 			},
 			ThirdParty: importers.List{
 				`"github.com/kat-co/vala"`,
-				`"github.com/pkg/errors"`,
+				`"github.com/friendsofgo/errors"`,
 				`"github.com/spf13/viper"`,
 				`"github.com/volatiletech/sqlboiler/drivers/sqlboiler-mssql/driver"`,
 				`"github.com/volatiletech/sqlboiler/randomize"`,

--- a/drivers/sqlboiler-mysql/driver/bindata.go
+++ b/drivers/sqlboiler-mysql/driver/bindata.go
@@ -264,15 +264,11 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"templates/17_upsert.go.tpl": templates17_upsertGoTpl,
-
-	"templates/singleton/mysql_upsert.go.tpl": templatesSingletonMysql_upsertGoTpl,
-
-	"templates_test/singleton/mysql_main_test.go.tpl": templates_testSingletonMysql_main_testGoTpl,
-
+	"templates/17_upsert.go.tpl":                        templates17_upsertGoTpl,
+	"templates/singleton/mysql_upsert.go.tpl":           templatesSingletonMysql_upsertGoTpl,
+	"templates_test/singleton/mysql_main_test.go.tpl":   templates_testSingletonMysql_main_testGoTpl,
 	"templates_test/singleton/mysql_suites_test.go.tpl": templates_testSingletonMysql_suites_testGoTpl,
-
-	"templates_test/upsert.go.tpl": templates_testUpsertGoTpl,
+	"templates_test/upsert.go.tpl":                      templates_testUpsertGoTpl,
 }
 
 // AssetDir returns the file names below a certain

--- a/drivers/sqlboiler-mysql/driver/mysql.go
+++ b/drivers/sqlboiler-mysql/driver/mysql.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/go-sql-driver/mysql"
-	"github.com/pkg/errors"
+	"github.com/friendsofgo/errors"
 	"github.com/volatiletech/sqlboiler/drivers"
 	"github.com/volatiletech/sqlboiler/importers"
 )
@@ -500,7 +500,7 @@ func (MySQLDriver) Imports() (col importers.Collection, err error) {
 			},
 			ThirdParty: importers.List{
 				`"github.com/kat-co/vala"`,
-				`"github.com/pkg/errors"`,
+				`"github.com/friendsofgo/errors"`,
 				`"github.com/spf13/viper"`,
 				`"github.com/volatiletech/sqlboiler/drivers/sqlboiler-mysql/driver"`,
 				`"github.com/volatiletech/sqlboiler/randomize"`,

--- a/drivers/sqlboiler-psql/driver/bindata.go
+++ b/drivers/sqlboiler-psql/driver/bindata.go
@@ -264,15 +264,11 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"templates/17_upsert.go.tpl": templates17_upsertGoTpl,
-
-	"templates/singleton/psql_upsert.go.tpl": templatesSingletonPsql_upsertGoTpl,
-
-	"templates_test/singleton/psql_main_test.go.tpl": templates_testSingletonPsql_main_testGoTpl,
-
+	"templates/17_upsert.go.tpl":                       templates17_upsertGoTpl,
+	"templates/singleton/psql_upsert.go.tpl":           templatesSingletonPsql_upsertGoTpl,
+	"templates_test/singleton/psql_main_test.go.tpl":   templates_testSingletonPsql_main_testGoTpl,
 	"templates_test/singleton/psql_suites_test.go.tpl": templates_testSingletonPsql_suites_testGoTpl,
-
-	"templates_test/upsert.go.tpl": templates_testUpsertGoTpl,
+	"templates_test/upsert.go.tpl":                     templates_testUpsertGoTpl,
 }
 
 // AssetDir returns the file names below a certain

--- a/drivers/sqlboiler-psql/driver/psql.go
+++ b/drivers/sqlboiler-psql/driver/psql.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/volatiletech/sqlboiler/importers"
 
-	"github.com/pkg/errors"
+	"github.com/friendsofgo/errors"
 	"github.com/volatiletech/sqlboiler/drivers"
 	"github.com/volatiletech/sqlboiler/strmangle"
 
@@ -633,7 +633,7 @@ func (p PostgresDriver) Imports() (importers.Collection, error) {
 			},
 			ThirdParty: importers.List{
 				`"github.com/kat-co/vala"`,
-				`"github.com/pkg/errors"`,
+				`"github.com/friendsofgo/errors"`,
 				`"github.com/spf13/viper"`,
 				`"github.com/volatiletech/sqlboiler/drivers/sqlboiler-psql/driver"`,
 				`"github.com/volatiletech/sqlboiler/randomize"`,

--- a/importers/imports.go
+++ b/importers/imports.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/spf13/cast"
 
-	"github.com/pkg/errors"
+	"github.com/friendsofgo/errors"
 	"github.com/volatiletech/sqlboiler/strmangle"
 )
 
@@ -201,7 +201,7 @@ func NewDefaultImports() Collection {
 			`"time"`,
 		},
 		ThirdParty: List{
-			`"github.com/pkg/errors"`,
+			`"github.com/friendsofgo/errors"`,
 			`"github.com/volatiletech/sqlboiler/boil"`,
 			`"github.com/volatiletech/sqlboiler/queries"`,
 			`"github.com/volatiletech/sqlboiler/queries/qm"`,
@@ -223,7 +223,7 @@ func NewDefaultImports() Collection {
 				`"strconv"`,
 			},
 			ThirdParty: List{
-				`"github.com/pkg/errors"`,
+				`"github.com/friendsofgo/errors"`,
 				`"github.com/volatiletech/sqlboiler/boil"`,
 				`"github.com/volatiletech/sqlboiler/strmangle"`,
 			},

--- a/importers/imports_test.go
+++ b/importers/imports_test.go
@@ -356,7 +356,7 @@ func TestMerge(t *testing.T) {
 var testImportStringExpect = `import (
 	"fmt"
 
-	"github.com/pkg/errors"
+	"github.com/friendsofgo/errors"
 )`
 
 func TestSetFormat(t *testing.T) {
@@ -367,7 +367,7 @@ func TestSetFormat(t *testing.T) {
 			`"fmt"`,
 		},
 		ThirdParty: List{
-			`"github.com/pkg/errors"`,
+			`"github.com/friendsofgo/errors"`,
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
+	"github.com/friendsofgo/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/volatiletech/sqlboiler/boilingcore"

--- a/queries/eager_load.go
+++ b/queries/eager_load.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/pkg/errors"
+	"github.com/friendsofgo/errors"
 	"github.com/volatiletech/sqlboiler/boil"
 	"github.com/volatiletech/sqlboiler/strmangle"
 )

--- a/queries/reflect.go
+++ b/queries/reflect.go
@@ -12,7 +12,7 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/pkg/errors"
+	"github.com/friendsofgo/errors"
 	"github.com/volatiletech/sqlboiler/boil"
 	"github.com/volatiletech/sqlboiler/strmangle"
 )

--- a/randomize/randomize.go
+++ b/randomize/randomize.go
@@ -9,7 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/pkg/errors"
+	"github.com/friendsofgo/errors"
 	"github.com/volatiletech/sqlboiler/strmangle"
 )
 

--- a/strmangle/strmangle_test.go
+++ b/strmangle/strmangle_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pkg/errors"
+	"github.com/friendsofgo/errors"
 )
 
 func TestIdentQuote(t *testing.T) {

--- a/templatebin/bindata.go
+++ b/templatebin/bindata.go
@@ -1104,95 +1104,51 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"templates/00_struct.go.tpl": templates00_structGoTpl,
-
-	"templates/01_types.go.tpl": templates01_typesGoTpl,
-
-	"templates/02_hooks.go.tpl": templates02_hooksGoTpl,
-
-	"templates/03_finishers.go.tpl": templates03_finishersGoTpl,
-
-	"templates/04_relationship_to_one.go.tpl": templates04_relationship_to_oneGoTpl,
-
-	"templates/05_relationship_one_to_one.go.tpl": templates05_relationship_one_to_oneGoTpl,
-
-	"templates/06_relationship_to_many.go.tpl": templates06_relationship_to_manyGoTpl,
-
-	"templates/07_relationship_to_one_eager.go.tpl": templates07_relationship_to_one_eagerGoTpl,
-
-	"templates/08_relationship_one_to_one_eager.go.tpl": templates08_relationship_one_to_one_eagerGoTpl,
-
-	"templates/09_relationship_to_many_eager.go.tpl": templates09_relationship_to_many_eagerGoTpl,
-
-	"templates/10_relationship_to_one_setops.go.tpl": templates10_relationship_to_one_setopsGoTpl,
-
-	"templates/11_relationship_one_to_one_setops.go.tpl": templates11_relationship_one_to_one_setopsGoTpl,
-
-	"templates/12_relationship_to_many_setops.go.tpl": templates12_relationship_to_many_setopsGoTpl,
-
-	"templates/13_all.go.tpl": templates13_allGoTpl,
-
-	"templates/14_find.go.tpl": templates14_findGoTpl,
-
-	"templates/15_insert.go.tpl": templates15_insertGoTpl,
-
-	"templates/16_update.go.tpl": templates16_updateGoTpl,
-
-	"templates/18_delete.go.tpl": templates18_deleteGoTpl,
-
-	"templates/19_reload.go.tpl": templates19_reloadGoTpl,
-
-	"templates/20_exists.go.tpl": templates20_existsGoTpl,
-
-	"templates/21_auto_timestamps.go.tpl": templates21_auto_timestampsGoTpl,
-
-	"templates/singleton/boil_queries.go.tpl": templatesSingletonBoil_queriesGoTpl,
-
-	"templates/singleton/boil_table_names.go.tpl": templatesSingletonBoil_table_namesGoTpl,
-
-	"templates/singleton/boil_types.go.tpl": templatesSingletonBoil_typesGoTpl,
-
-	"templates_test/00_types.go.tpl": templates_test00_typesGoTpl,
-
-	"templates_test/all.go.tpl": templates_testAllGoTpl,
-
-	"templates_test/delete.go.tpl": templates_testDeleteGoTpl,
-
-	"templates_test/exists.go.tpl": templates_testExistsGoTpl,
-
-	"templates_test/find.go.tpl": templates_testFindGoTpl,
-
-	"templates_test/finishers.go.tpl": templates_testFinishersGoTpl,
-
-	"templates_test/hooks.go.tpl": templates_testHooksGoTpl,
-
-	"templates_test/insert.go.tpl": templates_testInsertGoTpl,
-
-	"templates_test/relationship_one_to_one.go.tpl": templates_testRelationship_one_to_oneGoTpl,
-
+	"templates/00_struct.go.tpl":                           templates00_structGoTpl,
+	"templates/01_types.go.tpl":                            templates01_typesGoTpl,
+	"templates/02_hooks.go.tpl":                            templates02_hooksGoTpl,
+	"templates/03_finishers.go.tpl":                        templates03_finishersGoTpl,
+	"templates/04_relationship_to_one.go.tpl":              templates04_relationship_to_oneGoTpl,
+	"templates/05_relationship_one_to_one.go.tpl":          templates05_relationship_one_to_oneGoTpl,
+	"templates/06_relationship_to_many.go.tpl":             templates06_relationship_to_manyGoTpl,
+	"templates/07_relationship_to_one_eager.go.tpl":        templates07_relationship_to_one_eagerGoTpl,
+	"templates/08_relationship_one_to_one_eager.go.tpl":    templates08_relationship_one_to_one_eagerGoTpl,
+	"templates/09_relationship_to_many_eager.go.tpl":       templates09_relationship_to_many_eagerGoTpl,
+	"templates/10_relationship_to_one_setops.go.tpl":       templates10_relationship_to_one_setopsGoTpl,
+	"templates/11_relationship_one_to_one_setops.go.tpl":   templates11_relationship_one_to_one_setopsGoTpl,
+	"templates/12_relationship_to_many_setops.go.tpl":      templates12_relationship_to_many_setopsGoTpl,
+	"templates/13_all.go.tpl":                              templates13_allGoTpl,
+	"templates/14_find.go.tpl":                             templates14_findGoTpl,
+	"templates/15_insert.go.tpl":                           templates15_insertGoTpl,
+	"templates/16_update.go.tpl":                           templates16_updateGoTpl,
+	"templates/18_delete.go.tpl":                           templates18_deleteGoTpl,
+	"templates/19_reload.go.tpl":                           templates19_reloadGoTpl,
+	"templates/20_exists.go.tpl":                           templates20_existsGoTpl,
+	"templates/21_auto_timestamps.go.tpl":                  templates21_auto_timestampsGoTpl,
+	"templates/singleton/boil_queries.go.tpl":              templatesSingletonBoil_queriesGoTpl,
+	"templates/singleton/boil_table_names.go.tpl":          templatesSingletonBoil_table_namesGoTpl,
+	"templates/singleton/boil_types.go.tpl":                templatesSingletonBoil_typesGoTpl,
+	"templates_test/00_types.go.tpl":                       templates_test00_typesGoTpl,
+	"templates_test/all.go.tpl":                            templates_testAllGoTpl,
+	"templates_test/delete.go.tpl":                         templates_testDeleteGoTpl,
+	"templates_test/exists.go.tpl":                         templates_testExistsGoTpl,
+	"templates_test/find.go.tpl":                           templates_testFindGoTpl,
+	"templates_test/finishers.go.tpl":                      templates_testFinishersGoTpl,
+	"templates_test/hooks.go.tpl":                          templates_testHooksGoTpl,
+	"templates_test/insert.go.tpl":                         templates_testInsertGoTpl,
+	"templates_test/relationship_one_to_one.go.tpl":        templates_testRelationship_one_to_oneGoTpl,
 	"templates_test/relationship_one_to_one_setops.go.tpl": templates_testRelationship_one_to_one_setopsGoTpl,
-
-	"templates_test/relationship_to_many.go.tpl": templates_testRelationship_to_manyGoTpl,
-
-	"templates_test/relationship_to_many_setops.go.tpl": templates_testRelationship_to_many_setopsGoTpl,
-
-	"templates_test/relationship_to_one.go.tpl": templates_testRelationship_to_oneGoTpl,
-
-	"templates_test/relationship_to_one_setops.go.tpl": templates_testRelationship_to_one_setopsGoTpl,
-
-	"templates_test/reload.go.tpl": templates_testReloadGoTpl,
-
-	"templates_test/select.go.tpl": templates_testSelectGoTpl,
-
-	"templates_test/types.go.tpl": templates_testTypesGoTpl,
-
-	"templates_test/update.go.tpl": templates_testUpdateGoTpl,
-
-	"templates_test/singleton/boil_main_test.go.tpl": templates_testSingletonBoil_main_testGoTpl,
-
-	"templates_test/singleton/boil_queries_test.go.tpl": templates_testSingletonBoil_queries_testGoTpl,
-
-	"templates_test/singleton/boil_suites_test.go.tpl": templates_testSingletonBoil_suites_testGoTpl,
+	"templates_test/relationship_to_many.go.tpl":           templates_testRelationship_to_manyGoTpl,
+	"templates_test/relationship_to_many_setops.go.tpl":    templates_testRelationship_to_many_setopsGoTpl,
+	"templates_test/relationship_to_one.go.tpl":            templates_testRelationship_to_oneGoTpl,
+	"templates_test/relationship_to_one_setops.go.tpl":     templates_testRelationship_to_one_setopsGoTpl,
+	"templates_test/reload.go.tpl":                         templates_testReloadGoTpl,
+	"templates_test/select.go.tpl":                         templates_testSelectGoTpl,
+	"templates_test/types.go.tpl":                          templates_testTypesGoTpl,
+	"templates_test/update.go.tpl":                         templates_testUpdateGoTpl,
+	"templates_test/singleton/boil_main_test.go.tpl":       templates_testSingletonBoil_main_testGoTpl,
+	"templates_test/singleton/boil_queries_test.go.tpl":    templates_testSingletonBoil_queries_testGoTpl,
+	"templates_test/singleton/boil_suites_test.go.tpl":     templates_testSingletonBoil_suites_testGoTpl,
 }
 
 // AssetDir returns the file names below a certain


### PR DESCRIPTION
Switch to using github.com/friendsofgo/errors, a fork of github.com/pkg/errors, in order to provide error types which are compatible with _both_ github.com/pkg/errors and golang.org/pkg/errors

When used with go 1.13 or higher, this will use the builtin errors package with its new features; when used with older versions of go, it will use golang.org/x/xerrors, the backport of these features. 

See: 
- https://golang.org/pkg/errors/
- https://blog.golang.org/go1.13-errors

Relevant discussion:
- https://mycodesmells.com/post/migrating-pkg-errors-to-go-113-errors