### PR TITLE
Add usage/access example to Eager Loading in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1253,6 +1253,11 @@ for i := 0; i < len(jets); i++ {
 jets, _ := models.Jets(Load("Pilot")).All(ctx, db)
 // Type safe relationship names exist too:
 jets, _ := models.Jets(Load(models.JetRels.Pilot)).All(ctx, db)
+
+// Then access the loaded sructs using the special Relation field
+for _, j := range jets {
+  _ = j.R.Pilot
+}
 ```
 
 Eager loading can be combined with other query mods, and it can also eager load recursively.


### PR DESCRIPTION
From [looking at the Readme](https://github.com/volatiletech/sqlboiler#relationships), it was unclear how to actually *get* the related structs I had asked for using `qm.Load`.  It was only when I did some searching and newly looked at [a small taste](https://github.com/volatiletech/sqlboiler#a-small-taste) that I realized where they were.

This PR improves the documentation under the Relations/Eager Loading section so it becomes clear where the related structs are loaded to.