### PR TITLE
use (FALSE) instead of empty (column IN())

### DIFF
--- a/queries/query_builders.go
+++ b/queries/query_builders.go
@@ -371,10 +371,10 @@ ManualParen:
 			// for _, u := range model.Users(qm.WhereIn("id IN ?",uids...)).AllP(db) {
 			//    ...
 			// }
-			// instead when we see empty IN we produce FALSE so it can still be chained
+			// instead when we see empty IN we produce 1=9 so it can still be chained
 			// with other queries
 			if ln == 0 {
-				buf.WriteString("(FALSE)")
+				buf.WriteString("(1=0)")
 			} else {
 				matches := rgxInClause.FindStringSubmatch(where.clause)
 				// If we can't find any matches attempt a simple replace with 1 group.

--- a/queries/query_builders.go
+++ b/queries/query_builders.go
@@ -431,7 +431,6 @@ ManualParen:
 			}
 			startAt += leftCount + rightCount
 			args = append(args, where.args...)
-
 		default:
 			panic("unknown where type")
 		}

--- a/queries/query_builders.go
+++ b/queries/query_builders.go
@@ -367,60 +367,70 @@ ManualParen:
 			buf.WriteByte(')')
 		case whereKindIn:
 			ln := len(where.args)
-			matches := rgxInClause.FindStringSubmatch(where.clause)
-			// If we can't find any matches attempt a simple replace with 1 group.
-			// Clauses that fit this criteria will not be able to contain ? in their
-			// column name side, however if this case is being hit then the regexp
-			// probably needs adjustment, or the user is passing in invalid clauses.
-			if matches == nil {
-				clause, count := convertInQuestionMarks(q.dialect.UseIndexPlaceholders, where.clause, startAt, 1, ln)
+			// WHERE IN () is invalid sql, so it is difficult to simply run code like:
+			// for _, u := range model.Users(qm.WhereIn("id IN ?",uids...)).AllP(db) {
+			//    ...
+			// }
+			// instead when we see empty IN we produce FALSE so it can still be chained
+			// with other queries
+			if ln == 0 {
+				buf.WriteString("(FALSE)")
+			} else {
+				matches := rgxInClause.FindStringSubmatch(where.clause)
+				// If we can't find any matches attempt a simple replace with 1 group.
+				// Clauses that fit this criteria will not be able to contain ? in their
+				// column name side, however if this case is being hit then the regexp
+				// probably needs adjustment, or the user is passing in invalid clauses.
+				if matches == nil {
+					clause, count := convertInQuestionMarks(q.dialect.UseIndexPlaceholders, where.clause, startAt, 1, ln)
+					if !manualParens {
+						buf.WriteByte('(')
+					}
+					buf.WriteString(clause)
+					if !manualParens {
+						buf.WriteByte(')')
+					}
+					args = append(args, where.args...)
+					startAt += count
+					break
+				}
+
+				leftSide := strings.TrimSpace(matches[1])
+				rightSide := strings.TrimSpace(matches[2])
+				// If matches are found, we have to parse the left side (column side)
+				// of the clause to determine how many columns they are using.
+				// This number determines the groupAt for the convert function.
+				cols := strings.Split(leftSide, ",")
+				cols = strmangle.IdentQuoteSlice(q.dialect.LQ, q.dialect.RQ, cols)
+				groupAt := len(cols)
+
+				var leftClause string
+				var leftCount int
+				if q.dialect.UseIndexPlaceholders {
+					leftClause, leftCount = convertQuestionMarks(strings.Join(cols, ","), startAt)
+				} else {
+					// Count the number of cols that are question marks, so we know
+					// how much to offset convertInQuestionMarks by
+					for _, v := range cols {
+						if v == "?" {
+							leftCount++
+						}
+					}
+					leftClause = strings.Join(cols, ",")
+				}
+				rightClause, rightCount := convertInQuestionMarks(q.dialect.UseIndexPlaceholders, rightSide, startAt+leftCount, groupAt, ln-leftCount)
 				if !manualParens {
 					buf.WriteByte('(')
 				}
-				buf.WriteString(clause)
+				buf.WriteString(leftClause)
+				buf.WriteString(" IN ")
+				buf.WriteString(rightClause)
 				if !manualParens {
 					buf.WriteByte(')')
 				}
+				startAt += leftCount + rightCount
 				args = append(args, where.args...)
-				startAt += count
-				break
 			}
-
-			leftSide := strings.TrimSpace(matches[1])
-			rightSide := strings.TrimSpace(matches[2])
-			// If matches are found, we have to parse the left side (column side)
-			// of the clause to determine how many columns they are using.
-			// This number determines the groupAt for the convert function.
-			cols := strings.Split(leftSide, ",")
-			cols = strmangle.IdentQuoteSlice(q.dialect.LQ, q.dialect.RQ, cols)
-			groupAt := len(cols)
-
-			var leftClause string
-			var leftCount int
-			if q.dialect.UseIndexPlaceholders {
-				leftClause, leftCount = convertQuestionMarks(strings.Join(cols, ","), startAt)
-			} else {
-				// Count the number of cols that are question marks, so we know
-				// how much to offset convertInQuestionMarks by
-				for _, v := range cols {
-					if v == "?" {
-						leftCount++
-					}
-				}
-				leftClause = strings.Join(cols, ",")
-			}
-			rightClause, rightCount := convertInQuestionMarks(q.dialect.UseIndexPlaceholders, rightSide, startAt+leftCount, groupAt, ln-leftCount)
-			if !manualParens {
-				buf.WriteByte('(')
-			}
-			buf.WriteString(leftClause)
-			buf.WriteString(" IN ")
-			buf.WriteString(rightClause)
-			if !manualParens {
-				buf.WriteByte(')')
-			}
-			startAt += leftCount + rightCount
-			args = append(args, where.args...)
 		default:
 			panic("unknown where type")
 		}

--- a/queries/query_builders.go
+++ b/queries/query_builders.go
@@ -371,7 +371,7 @@ ManualParen:
 			// for _, u := range model.Users(qm.WhereIn("id IN ?",uids...)).AllP(db) {
 			//    ...
 			// }
-			// instead when we see empty IN we produce 1=9 so it can still be chained
+			// instead when we see empty IN we produce 1=0 so it can still be chained
 			// with other queries
 			if ln == 0 {
 				buf.WriteString("(1=0)")

--- a/queries/query_builders_test.go
+++ b/queries/query_builders_test.go
@@ -324,8 +324,19 @@ func TestInClause(t *testing.T) {
 			q: Query{
 				where: []where{{kind: whereKindIn, clause: "a in ?", args: []interface{}{}, orSeparator: true}},
 			},
-			expect: ` WHERE ("a" IN ())`,
+			expect: ` WHERE (FALSE)`,
 		},
+		{
+			q: Query{
+				where: []where{
+					where{kind: whereKindIn, clause: "a in ?", args: []interface{}{}, orSeparator: true},
+					where{kind: whereKindIn, clause: "a in ?", args: []interface{}{1}, orSeparator: true},
+				},
+			},
+			expect: ` WHERE (FALSE) OR ("a" IN ($1))`,
+			args:   []interface{}{1},
+		},
+
 		{
 			q: Query{
 				where: []where{{kind: whereKindIn, clause: "a in ?", args: []interface{}{1}, orSeparator: true}},

--- a/queries/query_builders_test.go
+++ b/queries/query_builders_test.go
@@ -324,7 +324,7 @@ func TestInClause(t *testing.T) {
 			q: Query{
 				where: []where{{kind: whereKindIn, clause: "a in ?", args: []interface{}{}, orSeparator: true}},
 			},
-			expect: ` WHERE (FALSE)`,
+			expect: ` WHERE (1=0)`,
 		},
 		{
 			q: Query{
@@ -333,7 +333,7 @@ func TestInClause(t *testing.T) {
 					where{kind: whereKindIn, clause: "a in ?", args: []interface{}{1}, orSeparator: true},
 				},
 			},
-			expect: ` WHERE (FALSE) OR ("a" IN ($1))`,
+			expect: ` WHERE (1=0) OR ("a" IN ($1))`,
 			args:   []interface{}{1},
 		},
 


### PR DESCRIPTION
when you pass empty slice to WhereIn, it generates `WHERE IN ()` which is invalid SQL, so it is difficult to simply run code
like:

for _, u := range model.Users(qm.WhereIn("id IN ?",uids...)).AllP(db) {
   ...
}
this patch generates `WHERE (FALSE)` instead of `WHERE column IN ()` so it is still chainable and there is no need to constantly check `if len(uids) > 0`
