### PR TITLE
Add ability to use WhereIn with any slice type

### DIFF
--- a/queries/qm/query_mods.go
+++ b/queries/qm/query_mods.go
@@ -245,7 +245,7 @@ func WhereIn(clause string, args ...interface{}) QueryMod {
 		val := reflect.ValueOf(args[0])
 		slice := make([]interface{}, val.Len())
 		for i := 0; i < val.Len(); i++ {
-			slice[i] = val.Index(i)
+			slice[i] = val.Index(i).Interface()
 		}
 		return WhereIn(clause, slice...)
 	}

--- a/queries/qm/query_mods.go
+++ b/queries/qm/query_mods.go
@@ -247,7 +247,10 @@ func WhereIn(clause string, args ...interface{}) QueryMod {
 		for i := 0; i < val.Len(); i++ {
 			slice[i] = val.Index(i).Interface()
 		}
-		return WhereIn(clause, slice...)
+		return whereInQueryMod{
+			clause: clause,
+			args:   slice,
+		}
 	}
 
 	return whereInQueryMod{

--- a/queries/qm/query_mods_test.go
+++ b/queries/qm/query_mods_test.go
@@ -32,10 +32,10 @@ func TestWhereIn(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
+	for n, test := range tests {
 		actual := test.Input()
 		if !reflect.DeepEqual(actual, test.Expected) {
-			t.Fatalf("actual %+v does not match expected %+v", actual, test.Expected)
+			t.Fatalf("test %d: actual %+v does not match expected %+v", n, actual, test.Expected)
 		}
 	}
 }

--- a/queries/qm/query_mods_test.go
+++ b/queries/qm/query_mods_test.go
@@ -1,0 +1,41 @@
+package qm
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestWhereIn(t *testing.T) {
+	tests := []struct {
+		Input    func() whereInQueryMod
+		Expected whereInQueryMod
+	}{
+		{
+			// Test standard ints
+			Input: func() whereInQueryMod {
+				return WhereIn("id in ?", 1, 2).(whereInQueryMod)
+			},
+			Expected: whereInQueryMod{
+				clause: "id in ?",
+				args:   []interface{}{1, 2},
+			},
+		},
+		{
+			// Test a slice
+			Input: func() whereInQueryMod {
+				return WhereIn("id in ?", []int{1, 2}).(whereInQueryMod)
+			},
+			Expected: whereInQueryMod{
+				clause: "id in ?",
+				args:   []interface{}{1, 2},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		actual := test.Input()
+		if !reflect.DeepEqual(actual, test.Expected) {
+			t.Fatalf("actual %+v does not match expected %+v", actual, test.Expected)
+		}
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/volatiletech/sqlboiler/issues/227 by using reflect to automatically convert any concrete slice type to a slice of interfaces where passed.

See https://github.com/volatiletech/sqlboiler/issues/227#issuecomment-589784513 for more info.

In summary, this PR allows us to:

```go
ids := []int{1, 2, 3, 4}
qm := WhereIn("id in ?", ids)
```

Verses before when we needed to:

```go
ids := []int{1, 2, 3, 4}

slice := make([]interface{}, len(ids))
for index, num := range ids {
        slice[index] = num
}

qm := WhereIn("id in ?", slice...)
```