### PR TITLE
bump  sqlBoilerVersion

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 
 //go:generate go-bindata -nometadata -pkg templatebin -o templatebin/bindata.go templates templates/singleton templates_test templates_test/singleton
 
-const sqlBoilerVersion = "3.6.1"
+const sqlBoilerVersion = "3.7.0"
 
 var (
 	flagConfigFile string


### PR DESCRIPTION
# What

Update `sqlBoilerVersion` in `main.go`.

# Why

This was causing `sqlboiler --version` to return `3.6.1` instead of `3.7.0`.