### PR TITLE
support enums that contain whitespace

### DIFF
--- a/boilingcore/templates.go
+++ b/boilingcore/templates.go
@@ -278,6 +278,7 @@ var templateFunctions = template.FuncMap{
 	"parseEnumName":       strmangle.ParseEnumName,
 	"parseEnumVals":       strmangle.ParseEnumVals,
 	"isEnumNormal":        strmangle.IsEnumNormal,
+	"stripWhitespace":     strmangle.StripWhitespace,
 	"shouldTitleCaseEnum": strmangle.ShouldTitleCaseEnum,
 	"onceNew":             newOnce,
 	"oncePut":             once.Put,

--- a/strmangle/strmangle.go
+++ b/strmangle/strmangle.go
@@ -18,8 +18,9 @@ var (
 	smartQuoteRgx = regexp.MustCompile(`^(?i)"?[a-z_][_a-z0-9\-]*"?(\."?[_a-z][_a-z0-9]*"?)*(\.\*)?$`)
 
 	rgxEnum            = regexp.MustCompile(`^enum(\.[a-z0-9_]+)?\((,?'[^']+')+\)$`)
-	rgxEnumIsOK        = regexp.MustCompile(`^(?i)[a-z][a-z0-9_]*$`)
+	rgxEnumIsOK        = regexp.MustCompile(`^(?i)[a-z][a-z0-9_\s]*$`)
 	rgxEnumShouldTitle = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+	rgxWhitespace      = regexp.MustCompile(`\s`)
 )
 
 var uppercaseWords = map[string]struct{}{
@@ -698,6 +699,11 @@ func IsEnumNormal(values []string) bool {
 	}
 
 	return true
+}
+
+//StripWhitespace removes all whitespace from a string
+func StripWhitespace(value string) string {
+	return rgxWhitespace.ReplaceAllString(value, "")
 }
 
 // ShouldTitleCaseEnum checks a value to see if it's title-case-able

--- a/strmangle/strmangle_test.go
+++ b/strmangle/strmangle_test.go
@@ -536,6 +536,7 @@ func TestParseEnum(t *testing.T) {
 		{"enum('one','two')", "", []string{"one", "two"}},
 		{"enum.working('one')", "working", []string{"one"}},
 		{"enum.wor_king('one','two')", "wor_king", []string{"one", "two"}},
+		{"enum('with space','two')", "", []string{"with space", "two"}},
 	}
 
 	for i, test := range tests {
@@ -562,6 +563,7 @@ func TestIsEnumNormal(t *testing.T) {
 		{[]string{"o1ne", "two2"}, true},
 		{[]string{"one", "t#wo2"}, false},
 		{[]string{"1one", "two2"}, false},
+		{[]string{"with space", "two"}, true},
 	}
 
 	for i, test := range tests {

--- a/templates/singleton/boil_types.go.tpl
+++ b/templates/singleton/boil_types.go.tpl
@@ -75,8 +75,9 @@ It only titlecases the EnumValue portion if it's snake-cased.
 // Enum values for {{if $isNamed}}{{$name}}{{else}}{{$table.Name}}.{{$col.Name}}{{end}}
 const (
 	{{- range $val := $vals -}}
+	{{- $valStripped := stripWhitespace $val -}}
 	{{- if $isNamed}}{{titleCase $name}}{{else}}{{titleCase $table.Name}}{{titleCase $col.Name}}{{end -}}
-	{{if shouldTitleCaseEnum $val}}{{titleCase $val}}{{else}}{{$val}}{{end}} = "{{$val}}"
+	{{if shouldTitleCaseEnum $valStripped}}{{titleCase $valStripped}}{{else}}{{$valStripped}}{{end}} = "{{$val}}"
 	{{end -}}
 )
 {{- else}}


### PR DESCRIPTION
If the value of an enum contained whitespace, it would be omitted from the generated code. This adds support for such enums.