### PR TITLE
Use reflect.Type as map keys where possible

### DIFF
--- a/queries/reflect.go
+++ b/queries/reflect.go
@@ -17,12 +17,15 @@ import (
 	"github.com/volatiletech/sqlboiler/strmangle"
 )
 
-var (
-	bindAccepts = []reflect.Kind{reflect.Ptr, reflect.Slice, reflect.Ptr, reflect.Struct}
+type colBindingKey struct {
+	typ     reflect.Type
+	colsKey string
+}
 
+var (
 	mut         sync.RWMutex
-	bindingMaps = make(map[string][]uint64)
-	structMaps  = make(map[string]map[string]uint64)
+	bindingMaps = make(map[colBindingKey][]uint64)
+	structMaps  = make(map[reflect.Type]map[string]uint64)
 )
 
 // Identifies what kind of object we're binding to
@@ -237,13 +240,12 @@ func bind(rows *sql.Rows, obj interface{}, structType, sliceType reflect.Type, b
 	var mapping []uint64
 	var ok bool
 
-	typKey := makeTypeKey(structType)
 	colsKey := makeColsKey(structType, cols)
 
 	mut.RLock()
 	mapping, ok = bindingMaps[colsKey]
 	if !ok {
-		if strMapping, sok = structMaps[typKey]; !sok {
+		if strMapping, sok = structMaps[structType]; !sok {
 			strMapping = MakeStructMapping(structType)
 		}
 	}
@@ -257,7 +259,7 @@ func bind(rows *sql.Rows, obj interface{}, structType, sliceType reflect.Type, b
 
 		mut.Lock()
 		if !sok {
-			structMaps[typKey] = strMapping
+			structMaps[structType] = strMapping
 		}
 		bindingMaps[colsKey] = mapping
 		mut.Unlock()
@@ -439,30 +441,18 @@ func getBoilTag(field reflect.StructField) (name string, recurse bool) {
 	return nameFragment, true
 }
 
-func makeTypeKey(typ reflect.Type) string {
+func makeColsKey(typ reflect.Type, cols []string) colBindingKey {
 	buf := strmangle.GetBuffer()
-	buf.WriteString(typ.String())
-	for i, n := 0, typ.NumField(); i < n; i++ {
-		field := typ.Field(i)
-		buf.WriteString(field.Name)
-		buf.WriteString(field.Type.String())
-	}
-	hash := buf.String()
-	strmangle.PutBuffer(buf)
-
-	return hash
-}
-
-func makeColsKey(typ reflect.Type, cols []string) string {
-	buf := strmangle.GetBuffer()
-	buf.WriteString(typ.String())
 	for _, s := range cols {
 		buf.WriteString(s)
 	}
 	hash := buf.String()
 	strmangle.PutBuffer(buf)
 
-	return hash
+	return colBindingKey{
+		typ:     typ,
+		colsKey: hash,
+	}
 }
 
 // Equal is different to reflect.DeepEqual in that it's both less efficient


### PR DESCRIPTION
While profiling my project, I found that a significant portion of my CPU time and memory allocations were being spent calculating the map keys for cached bindings. These keys are produced by hand from `reflect.Type`s, however the documentation for `reflect.Type` says that they are comparable by `==` and therefore usable as map keys.

By using `reflect.Type` as map keys where possible, I was able to eliminate sqlboiler's binding code from my profiles entirely, giving me a significant performance boost. Some benchmarks from my project (where each of these involve a few queries):

```
name                   old time/op    new time/op    delta
HandleNop-4               384µs ±11%     364µs ± 2%   -5.23%  (p=0.000 n=10+9)
HandleNopParallel-4       259µs ± 3%     248µs ± 0%   -4.31%  (p=0.000 n=9+8)
HandleCustomCommand-4     376µs ± 2%     378µs ±20%     ~     (p=0.059 n=8+9)
HandleMixed-4             387µs ±10%     366µs ± 0%   -5.48%  (p=0.000 n=9+7)

name                   old alloc/op   new alloc/op   delta
HandleNop-4              9.40kB ± 0%    7.91kB ± 0%  -15.84%  (p=0.000 n=10+9)
HandleNopParallel-4      9.46kB ± 0%    7.95kB ± 0%  -15.88%  (p=0.000 n=10+8)
HandleCustomCommand-4    9.40kB ± 0%    7.91kB ± 0%  -15.84%  (p=0.000 n=8+10)
HandleMixed-4            9.44kB ± 0%    7.95kB ± 0%  -15.76%  (p=0.000 n=10+10)

name                   old allocs/op  new allocs/op  delta
HandleNop-4                 150 ± 0%        92 ± 0%  -38.67%  (p=0.000 n=10+10)
HandleNopParallel-4         150 ± 0%        92 ± 0%  -38.67%  (p=0.000 n=10+10)
HandleCustomCommand-4       150 ± 0%        92 ± 0%  -38.67%  (p=0.000 n=10+10)
HandleMixed-4               151 ± 0%        93 ± 0%  -38.41%  (p=0.000 n=10+10)
```

I have not yet figured out how to run sqlboiler's own test/benchmark suite, but I believe the tests will pass and a similar performance boost will be seen. I'd appreciate help on that front; I don't know the last time the benchmarks in the README have been updated and this might improve them. :smiley:

I believe this new code is more correct as well; the old code created its hash with `String()`, which the `reflect.Type` docs say not to compare as they shorten package names like `encoding/base64` down to `base64` (meaning it's possible there were collisions before for types which were not actually equal). This may mean more entries in the caches, however the sizes should still be bounded by the number of types in a given program.

There are other candidates in `reflect.go` for memory improvements (some preallocs, more key changes), however the fact that these bindings are only generated once (and accessed so easily) means that a few extra allocations here and there end up not mattering in comparison to this PR alone.