### PR TITLE
Added NIN helper

### DIFF
--- a/templates/00_struct.go.tpl
+++ b/templates/00_struct.go.tpl
@@ -59,6 +59,13 @@ func (w {{$name}}) IN(slice []{{.Type}}) qm.QueryMod {
   }
   return qm.WhereIn(fmt.Sprintf("%s IN ?", w.field), values...)
 }
+func (w {{$name}}) NIN(slice []{{.Type}}) qm.QueryMod {
+	values := make([]interface{}, 0, len(slice))
+	for _, value := range slice {
+	  values = append(values, value)
+	}
+	return qm.WhereIn(fmt.Sprintf("%s NOT IN ?", w.field), values...)
+  }
 {{end -}}
 	{{- end -}}
 {{- end}}


### PR DESCRIPTION
This way I can create universal helpers for https://github.com/web-ridge/gqlgen-sqlboiler

e.g like this:

```golang
type WhereUint interface {
	IN(slice []uint) qm.QueryMod
	NIN(slice []uint) qm.QueryMod
}

func IDFilterToMods(m *graphql_models.IDFilter, whereHelper WhereUint) []qm.QueryMod {
	var queryMods []qm.QueryMod
	queryMods = append(queryMods, whereHelper.IN(helper.IDsToBoiler(m.In)))
	queryMods = append(queryMods, whereHelper.NIN(helper.IDsToBoiler(m.NotIn)))
	return queryMods
}
```