### PR TITLE
Add template to generate order clause

### DIFF
--- a/templates/22_order.go.tpl
+++ b/templates/22_order.go.tpl
@@ -1,0 +1,15 @@
+{{- $alias := .Aliases.Table .Table.Name -}}
+
+var {{$alias.UpSingular}}Order = struct {
+	{{range $column := .Table.Columns -}}
+	{{- $colAlias := $alias.Column $column.Name -}}
+	{{$colAlias}}Asc string
+	{{$colAlias}}Desc string
+	{{end -}}
+}{
+	{{range $column := .Table.Columns -}}
+	{{- $colAlias := $alias.Column $column.Name -}}
+	{{$colAlias}}Asc: "{{$.Table.Name | $.SchemaTable}}.{{$column.Name | $.Quotes}} ASC",
+	{{$colAlias}}Desc: "{{$.Table.Name | $.SchemaTable}}.{{$column.Name | $.Quotes}} DESC",
+	{{end -}}
+}


### PR DESCRIPTION
I have added a template that generates the code below.
```
var Book = struct {
  IDAsc string
  IDDesc string
  NameAsc string
  NameDesc string
}{
  IDAsc: "\"books\".\"id\" ASC",
  IDDesc: "\"books\".\"id\" DESC",
  NameAsc: "\"books\".\"name\" ASC",
  NameDesc: "\"books\".\"name\" DESC",
}
```
This generated code is used as follows.
```
qm.OrderBy(BookOrder.NameDesc),
qm.OrderBy(BookOrder.IDAsc),
```

Thanks.