### PR TITLE
Bind: add support for Structs with pointers

### DIFF
--- a/queries/reflect_test.go
+++ b/queries/reflect_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/volatiletech/null/v8/convert"
 	"github.com/volatiletech/sqlboiler/v4/drivers"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -40,12 +41,25 @@ type mockRowMaker struct {
 	rows []driver.Value
 }
 
+type StructField struct {
+	Name string
+}
+
+func (s *StructField) Scan(value interface{}) error {
+	if value == nil {
+		return nil
+	}
+	err := convert.ConvertAssign(&s.Name, value)
+	return err
+}
+
 func TestBindStruct(t *testing.T) {
 	t.Parallel()
 
 	testResults := struct {
 		ID   int
 		Name string `boil:"test"`
+		TestPtr *StructField
 	}{}
 
 	query := &Query{
@@ -58,9 +72,9 @@ func TestBindStruct(t *testing.T) {
 		t.Error(err)
 	}
 
-	ret := sqlmock.NewRows([]string{"id", "test"})
-	ret.AddRow(driver.Value(int64(35)), driver.Value("pat"))
-	ret.AddRow(driver.Value(int64(65)), driver.Value("hat"))
+	ret := sqlmock.NewRows([]string{"id", "test", "test_ptr"})
+	ret.AddRow(driver.Value(int64(35)), driver.Value("pat"), driver.Value("pat2"))
+	ret.AddRow(driver.Value(int64(65)), driver.Value("hat"), driver.Value("hat2"))
 	mock.ExpectQuery(`SELECT \* FROM "fun";`).WillReturnRows(ret)
 
 	err = query.Bind(nil, db, &testResults)
@@ -74,6 +88,9 @@ func TestBindStruct(t *testing.T) {
 	if name := testResults.Name; name != "pat" {
 		t.Error("wrong name:", name)
 	}
+	if name := testResults.TestPtr.Name; name != "pat2" {
+		t.Error("wrong name2:", name)
+	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Error(err)
@@ -86,6 +103,7 @@ func TestBindSlice(t *testing.T) {
 	testResults := []struct {
 		ID   int
 		Name string `boil:"test"`
+		TestPtr *StructField
 	}{}
 
 	query := &Query{
@@ -98,9 +116,9 @@ func TestBindSlice(t *testing.T) {
 		t.Error(err)
 	}
 
-	ret := sqlmock.NewRows([]string{"id", "test"})
-	ret.AddRow(driver.Value(int64(35)), driver.Value("pat"))
-	ret.AddRow(driver.Value(int64(12)), driver.Value("cat"))
+	ret := sqlmock.NewRows([]string{"id", "test", "test_ptr"})
+	ret.AddRow(driver.Value(int64(35)), driver.Value("pat"), driver.Value("pat2"))
+	ret.AddRow(driver.Value(int64(12)), driver.Value("cat"), driver.Value("cat2"))
 	mock.ExpectQuery(`SELECT \* FROM "fun";`).WillReturnRows(ret)
 
 	err = query.Bind(nil, db, &testResults)
@@ -117,12 +135,18 @@ func TestBindSlice(t *testing.T) {
 	if name := testResults[0].Name; name != "pat" {
 		t.Error("wrong name:", name)
 	}
+	if name := testResults[0].TestPtr.Name; name != "pat2" {
+		t.Error("wrong name2:", name)
+	}
 
 	if id := testResults[1].ID; id != 12 {
 		t.Error("wrong ID:", id)
 	}
 	if name := testResults[1].Name; name != "cat" {
 		t.Error("wrong name:", name)
+	}
+	if name := testResults[1].TestPtr.Name; name != "cat2" {
+		t.Error("wrong name2:", name)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -444,6 +468,7 @@ func TestBindSingular(t *testing.T) {
 	testResults := struct {
 		ID   int
 		Name string `boil:"test"`
+		TestPtr *StructField
 	}{}
 
 	query := &Query{
@@ -456,8 +481,8 @@ func TestBindSingular(t *testing.T) {
 		t.Error(err)
 	}
 
-	ret := sqlmock.NewRows([]string{"id", "test"})
-	ret.AddRow(driver.Value(int64(35)), driver.Value("pat"))
+	ret := sqlmock.NewRows([]string{"id", "test", "test_ptr"})
+	ret.AddRow(driver.Value(int64(35)), driver.Value("pat"), driver.Value("pat2"))
 	mock.ExpectQuery(`SELECT \* FROM "fun";`).WillReturnRows(ret)
 
 	err = query.Bind(nil, db, &testResults)
@@ -470,6 +495,9 @@ func TestBindSingular(t *testing.T) {
 	}
 	if name := testResults.Name; name != "pat" {
 		t.Error("wrong name:", name)
+	}
+	if name := testResults.TestPtr.Name; name != "pat2" {
+		t.Error("wrong name2:", name)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {


### PR DESCRIPTION
This makes it possible, for example, to bind to Structs generated by proto3 which contain pointers to Structs.

Here is an example:
```protobuf
// proto3
message Book {
  int64 id = 1;
  string author = 2;
  string title = 3;
  NullableString subtitle = 4;
}

message NullableString {
  string string = 1;
  bool valid = 2;
}
```

Which results in the following Go structs:
```go
type Book struct {
    ID       int64
    Author   string
    Title    string
    Subtitle *NullableString
}

type NullableString struct {
    String_  string
    Valid    bool
    ...
}
```
To make `Bind()` work with this example, one has to implement `Scan()` for `NullableString`:
```go
func (s *NullableString) Scan(value interface{}) error {
	if value == nil {
		s.String_, s.Valid = "", false
		return nil
	}
	s.Valid = true
	err := convert.ConvertAssign(&s.String_, value)
	return err
}
```
```