### PR TITLE
Mysql MariaDB (fix 1)

### DIFF
--- a/drivers/sqlboiler-mysql/driver/mysql.go
+++ b/drivers/sqlboiler-mysql/driver/mysql.go
@@ -192,7 +192,11 @@ func (m *MySQLDriver) Columns(schema, tableName string, whitelist, blacklist []s
 	c.column_name,
 	c.column_type,
 	if(c.data_type = 'enum', c.column_type, c.data_type),
-	if(extra = 'auto_increment','auto_increment', c.column_default),
+	if(extra = 'auto_increment','auto_increment', 
+		if(version() like "%MariaDB%" and c.column_default = 'NULL', '',
+		if(version() like "%MariaDB%" and c.data_type in ('varchar','char','binary','date','datetime','time'), 
+			replace(substring(c.column_default,2,length(c.column_default)-2),"''","'")
+				c.column_default))),
 	c.is_nullable = 'YES',
 		exists (
 			select c.column_name


### PR DESCRIPTION
First: Sorry but this is an incremental PR to be added after the slow MySQL fix PR. I need need to work with the code and creating a PR on master for this makes no sense for me as MySQL is unusable on my system without the fix for the generation speed.

It addresses the problem that MariaDB stores default values in a different way in the information schema. The MySQL driver test fails for MariaDB and this is part of the reason why this happens.

There are other reasons too but the different storage of the default values seems to be a real problem with sqlboiler as it would use the wrong values (`'abc'` instead of `abc`).

I actually wonder that MySQL seems to use an empty string for the NULL value. But I added that too.

There is also `CURRENT_TIMESTAMP` vs `current_timestamp()` and a different encoding for 0 bytes (`\u000` vs `\\0`). But those are just making the test fail because of the tester expecting the fixed format MySQL is using. I think it does not really matter for sqlboiler functionality.