### PR TITLE
Allow targeting column by table name in types.match

### DIFF
--- a/boilingcore/boilingcore.go
+++ b/boilingcore/boilingcore.go
@@ -420,6 +420,10 @@ func (s *State) processTypeReplacements() error {
 		for i := range s.Tables {
 			t := s.Tables[i]
 
+			if !shouldReplaceInTable(t, r) {
+				continue
+			}
+
 			for j := range t.Columns {
 				c := t.Columns[j]
 				if matchColumn(c, r.Match) {
@@ -519,6 +523,22 @@ func columnMerge(dst, src drivers.Column) drivers.Column {
 	}
 
 	return ret
+}
+
+// shouldReplaceInTable checks if tables were specified in types.match in the config.
+// If tables were set, it checks if the given table is among the specified tables.
+func shouldReplaceInTable(t drivers.Table, r TypeReplace) bool {
+	if len(r.Tables) == 0 {
+		return true
+	}
+
+	for _, replaceInTable := range r.Tables {
+		if replaceInTable == t.Name {
+			return true
+		}
+	}
+
+	return false
 }
 
 // initOutFolders creates the folders that will hold the generated output.

--- a/boilingcore/boilingcore_test.go
+++ b/boilingcore/boilingcore_test.go
@@ -192,6 +192,18 @@ func TestProcessTypeReplacements(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "named_table",
+			Columns: []drivers.Column{
+				{
+					Name:     "id",
+					Type:     "int",
+					DBType:   "serial",
+					Default:  "some db nonsense",
+					Nullable: false,
+				},
+			},
+		},
 	}
 
 	s.Config.TypeReplaces = []TypeReplace{
@@ -204,6 +216,18 @@ func TestProcessTypeReplacements(t *testing.T) {
 			},
 			Imports: importers.Set{
 				ThirdParty: []string{`"rock.com/excellent"`},
+			},
+		},
+		{
+			Tables: []string{"named_table"},
+			Match: drivers.Column{
+				DBType: "serial",
+			},
+			Replace: drivers.Column{
+				Type: "excellent.NamedType",
+			},
+			Imports: importers.Set{
+				ThirdParty: []string{`"rock.com/excellent-name"`},
 			},
 		},
 		{
@@ -253,6 +277,13 @@ func TestProcessTypeReplacements(t *testing.T) {
 		t.Error("type was wrong:", typ)
 	}
 	if i := s.Config.Imports.BasedOnType["big.Int"].Standard[0]; i != `"math/big"` {
+		t.Error("imports were not adjusted")
+	}
+
+	if typ := s.Tables[1].Columns[0].Type; typ != "excellent.NamedType" {
+		t.Error("type was wrong:", typ)
+	}
+	if i := s.Config.Imports.BasedOnType["excellent.NamedType"].ThirdParty[0]; i != `"rock.com/excellent-name"` {
 		t.Error("imports were not adjusted")
 	}
 }

--- a/boilingcore/config.go
+++ b/boilingcore/config.go
@@ -45,6 +45,7 @@ type Config struct {
 
 // TypeReplace replaces a column type with something else
 type TypeReplace struct {
+	Tables  []string       `toml:"tables,omitempty" json:"tables,omitempty"`
 	Match   drivers.Column `toml:"match,omitempty" json:"match,omitempty"`
 	Replace drivers.Column `toml:"replace,omitempty" json:"replace,omitempty"`
 	Imports importers.Set  `toml:"imports,omitempty" json:"imports,omitempty"`
@@ -194,6 +195,8 @@ func ConvertTypeReplace(i interface{}) []TypeReplace {
 		replace.Match = columnFromInterface(replaceIntf["match"])
 		replace.Replace = columnFromInterface(replaceIntf["replace"])
 
+		replace.Tables = tablesOfTypeReplace(replaceIntf["match"])
+
 		if imps := replaceIntf["imports"]; imps != nil {
 			imps = cast.ToStringMap(imps)
 			var err error
@@ -207,6 +210,17 @@ func ConvertTypeReplace(i interface{}) []TypeReplace {
 	}
 
 	return replaces
+}
+
+func tablesOfTypeReplace(i interface{}) []string {
+	tables := []string{}
+
+	m := cast.ToStringMap(i)
+	if s := m["tables"]; s != nil {
+		tables = cast.ToStringSlice(s)
+	}
+
+	return tables
 }
 
 func columnFromInterface(i interface{}) (col drivers.Column) {

--- a/boilingcore/config_test.go
+++ b/boilingcore/config_test.go
@@ -1,6 +1,7 @@
 package boilingcore
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/volatiletech/sqlboiler/v4/drivers"
@@ -186,6 +187,7 @@ func TestConvertTypeReplace(t *testing.T) {
 		"udt_name":       "d",
 		"full_db_type":   "e",
 		"arr_type":       "f",
+		"tables":         []string{"g", "h"},
 		"auto_generated": true,
 		"nullable":       true,
 	}
@@ -247,5 +249,8 @@ func TestConvertTypeReplace(t *testing.T) {
 	}
 	if got := r.Imports.ThirdParty[0]; got != "github.com/abc" {
 		t.Error("standard import wrong:", got)
+	}
+	if got := r.Tables; !reflect.DeepEqual(r.Tables, []string{"g", "h"}) {
+		t.Error("tables in types.match wrong:", got)
 	}
 }


### PR DESCRIPTION
Looks for "tables" in types.match and if present,
will replace the columns only on those tables.

Implements #599 

Fully backward compatible.

### Something to note

With this implementation, more specific columns have to come at the end of the types.match array. If not, they will be overwritten.

For example, given

```toml
[[types]]
  [types.match]
    tables = ['users']
    name = "created_at"
    nullable = true

  [types.replace]
    type = "mine.CustomType"

  [types.imports]
    third_party = ['"gitlab.com/example/mine"']
    
[[types]]
  [types.match]
    name = "created_at"
    nullable = true

  [types.replace]
    type = "mine.AType"

  [types.imports]
    third_party = ['"gitlab.com/example/mine"']
```
In the generated model, we will have 

```go
package models

import (
	"gitlab.com/example/mine"
)

type User struct {
	CreatedAt          mine.AType  `boil:"created_at" json:"created_at,omitempty" toml:"created_at" yaml:"created_at,omitempty"`
}
```

Instead we must properly order our config like this:

```toml
[[types]]
  [types.match]
    name = "created_at"
    nullable = true

  [types.replace]
    type = "mine.AType"

  [types.imports]
    third_party = ['"gitlab.com/example/mine"']

[[types]]
  [types.match]
    tables = ['users']
    name = "created_at"
    nullable = true

  [types.replace]
    type = "mine.CustomType"

  [types.imports]
    third_party = ['"gitlab.com/example/mine"']
```

And then as we would probably like, we get:

```go
package models

import (
	"gitlab.com/example/mine"
)

type User struct {
	CreatedAt          mine.CustomType `boil:"created_at" json:"created_at,omitempty" toml:"created_at" yaml:"created_at,omitempty"`
}
```

