### PR TITLE
Add support for custom build tags

### DIFF
--- a/boilingcore/config.go
+++ b/boilingcore/config.go
@@ -34,6 +34,8 @@ type Config struct {
 	StructTagCasing   string   `toml:"struct_tag_casing,omitempty" json:"struct_tag_casing,omitempty"`
 	RelationTag       string   `toml:"relation_tag,omitempty" json:"relation_tag,omitempty"`
 	TagIgnore         []string `toml:"tag_ignore,omitempty" json:"tag_ignore,omitempty"`
+	BuildTags         []string `toml:"build_tags,omitempty" json:"build_tags,omitempty"`
+	TestBuildTags     []string `toml:"test_build_tags,omitempty" json:"test_build_tags,omitempty"`
 
 	Imports importers.Collection `toml:"imports,omitempty" json:"imports,omitempty"`
 

--- a/main.go
+++ b/main.go
@@ -111,6 +111,8 @@ func main() {
 	rootCmd.PersistentFlags().StringP("struct-tag-casing", "", "snake", "Decides the casing for go structure tag names. camel, title or snake (default snake)")
 	rootCmd.PersistentFlags().StringP("relation-tag", "r", "-", "Relationship struct tag name")
 	rootCmd.PersistentFlags().StringSliceP("tag-ignore", "", nil, "List of column names that should have tags values set to '-' (ignored during parsing)")
+	rootCmd.PersistentFlags().StringSliceP("build-tags", "", nil, "List of go build tags that should be added to all non-test .go files")
+	rootCmd.PersistentFlags().StringSliceP("test-build-tags", "", nil, "List of go build tags that should be added to all test .go files")
 
 	// hide flags not recommended for use
 	rootCmd.PersistentFlags().MarkHidden("replace")
@@ -183,6 +185,8 @@ func preRun(cmd *cobra.Command, args []string) error {
 		Wipe:              viper.GetBool("wipe"),
 		StructTagCasing:   strings.ToLower(viper.GetString("struct-tag-casing")), // camel | snake | title
 		TagIgnore:         viper.GetStringSlice("tag-ignore"),
+		BuildTags:         viper.GetStringSlice("build-tags"),
+		TestBuildTags:     viper.GetStringSlice("test-build-tags"),
 		RelationTag:       viper.GetString("relation-tag"),
 		TemplateDirs:      viper.GetStringSlice("templates"),
 		Tags:              viper.GetStringSlice("tag"),


### PR DESCRIPTION
  If a user desires for unit tests to run without accessing external
  resources (a database) but still wishes to make use of the
  autogenerated tests, they may specify test-build-tags to add go build
  tags, https://golang.org/pkg/go/build/#hdr-Build_Constraints, to their
  test files. For example a user may set test-build-tags to
  ["integration"] and continue to run unit tests without a database.
  When a database is available, the test binary may be built with `-tags
  integration` to run the autogenerated sqlboiler tests.