### PR TITLE
Ignore generated columns for psql

### DIFF
--- a/drivers/sqlboiler-psql/driver/psql.go
+++ b/drivers/sqlboiler-psql/driver/psql.go
@@ -262,7 +262,7 @@ func (p *PostgresDriver) Columns(schema, tableName string, whitelist, blacklist 
 				end
 			) as column_type
 		) ct
-		where c.table_name = $2 and c.table_schema = $1`
+		where c.table_name = $2 and c.table_schema = $1 and c.is_generated = 'NEVER'`
 
 	if len(whitelist) > 0 {
 		cols := drivers.ColumnsFromList(whitelist, tableName)


### PR DESCRIPTION
psql's [generated columns](https://www.postgresql.org/docs/12/ddl-generated-columns.html) cannot be set. So this PR add condition to filter those columns.
mysql driver already ignores virtual columns (which is generated column in psql) in #266