### PR TITLE
Add --extra-templates option

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ Flags:
       --add-soft-deletes           Enable soft deletion by updating deleted_at timestamp
   -c, --config string              Filename of config file to override default lookup
   -d, --debug                      Debug mode prints stack traces on error
+      --extra-templates string     The additional templates directory, that does not override the bindata's template folders in sqlboiler
   -h, --help                       help for sqlboiler
       --no-auto-timestamps         Disable automatic timestamps for created_at/updated_at
       --no-back-referencing        Disable back referencing in the loaded relationship structs
@@ -735,12 +736,21 @@ output_dir/
 
 **Note**: Because the `--templates` flag overrides the internal bindata of `sqlboiler`, if you still
 wish to generate the default templates it's recommended that you include the path to sqlboiler's templates
-as well.
+as well. 
+Either you can use `--extra-templates` to specify additional (to those included in internal bindata) templates directories.
 
 ```toml
 templates = [
   "/path/to/sqlboiler/templates",
   "/path/to/sqlboiler/templates_test",
+  "/path/to/your_project/more_templates"
+]
+```
+
+Or
+
+```toml
+extra_templates = [
   "/path/to/your_project/more_templates"
 ]
 ```

--- a/boilingcore/boilingcore.go
+++ b/boilingcore/boilingcore.go
@@ -251,6 +251,23 @@ func (s *State) initTemplates() ([]lazyTemplate, error) {
 			}
 		}
 	}
+	if len(s.Config.ExtraTemplateDirs) != 0 {
+		for _, dir := range s.Config.ExtraTemplateDirs {
+			abs, err := filepath.Abs(dir)
+			if err != nil {
+				return nil, errors.Wrap(err, "could not find abs dir of templates directory")
+			}
+
+			base := filepath.Base(abs)
+			root := filepath.Dir(abs)
+			tpls, err := findTemplates(root, base)
+			if err != nil {
+				return nil, err
+			}
+
+			mergeTemplates(templates, tpls)
+		}
+	}
 
 	if !s.Config.NoDriverTemplates {
 		driverTemplates, err := s.Driver.Templates()

--- a/boilingcore/config.go
+++ b/boilingcore/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	PkgName           string   `toml:"pkg_name,omitempty" json:"pkg_name,omitempty"`
 	OutFolder         string   `toml:"out_folder,omitempty" json:"out_folder,omitempty"`
 	TemplateDirs      []string `toml:"template_dirs,omitempty" json:"template_dirs,omitempty"`
+	ExtraTemplateDirs []string `toml:"extra_template_dirs,omitempty" json:"extra_template_dirs,omitempty"`
 	Tags              []string `toml:"tags,omitempty" json:"tags,omitempty"`
 	Replacements      []string `toml:"replacements,omitempty" json:"replacements,omitempty"`
 	Debug             bool     `toml:"debug,omitempty" json:"debug,omitempty"`

--- a/main.go
+++ b/main.go
@@ -93,6 +93,7 @@ func main() {
 	rootCmd.PersistentFlags().StringP("output", "o", "models", "The name of the folder to output to")
 	rootCmd.PersistentFlags().StringP("pkgname", "p", "models", "The name you wish to assign to your generated package")
 	rootCmd.PersistentFlags().StringSliceP("templates", "", nil, "A templates directory, overrides the bindata'd template folders in sqlboiler")
+	rootCmd.PersistentFlags().StringSliceP("extra-templates", "", nil, "A templates directory, does not override the bindata'd template folders in sqlboiler")
 	rootCmd.PersistentFlags().StringSliceP("tag", "t", nil, "Struct tags to be included on your models in addition to json, yaml, toml")
 	rootCmd.PersistentFlags().StringSliceP("replace", "", nil, "Replace templates by directory: relpath/to_file.tpl:relpath/to_replacement.tpl")
 	rootCmd.PersistentFlags().BoolP("debug", "d", false, "Debug mode prints stack traces on error")
@@ -185,6 +186,7 @@ func preRun(cmd *cobra.Command, args []string) error {
 		TagIgnore:         viper.GetStringSlice("tag-ignore"),
 		RelationTag:       viper.GetString("relation-tag"),
 		TemplateDirs:      viper.GetStringSlice("templates"),
+		ExtraTemplateDirs: viper.GetStringSlice("extra-templates"),
 		Tags:              viper.GetStringSlice("tag"),
 		Replacements:      viper.GetStringSlice("replace"),
 		Aliases:           boilingcore.ConvertAliases(viper.Get("aliases")),

--- a/main.go
+++ b/main.go
@@ -93,7 +93,7 @@ func main() {
 	rootCmd.PersistentFlags().StringP("output", "o", "models", "The name of the folder to output to")
 	rootCmd.PersistentFlags().StringP("pkgname", "p", "models", "The name you wish to assign to your generated package")
 	rootCmd.PersistentFlags().StringSliceP("templates", "", nil, "A templates directory, overrides the bindata'd template folders in sqlboiler")
-	rootCmd.PersistentFlags().StringSliceP("extra-templates", "", nil, "A templates directory, does not override the bindata'd template folders in sqlboiler")
+	rootCmd.PersistentFlags().StringSliceP("extra-templates", "", nil, "The additional templates directory, that does not override the bindata's template folders in sqlboiler")
 	rootCmd.PersistentFlags().StringSliceP("tag", "t", nil, "Struct tags to be included on your models in addition to json, yaml, toml")
 	rootCmd.PersistentFlags().StringSliceP("replace", "", nil, "Replace templates by directory: relpath/to_file.tpl:relpath/to_replacement.tpl")
 	rootCmd.PersistentFlags().BoolP("debug", "d", false, "Debug mode prints stack traces on error")


### PR DESCRIPTION
#755

This is a change to add the `--extra-templates` option.
It works the same way as `--templates`, but we don't need to specify original templates.

The following is a log of the test run.

Preparing:

```bash
# build a binary at my sqlboiler repository dir.
root@517e8bbfecb1:/sqlboiler# go build -o sqlboiler .
# copy
root@517e8bbfecb1:/sqlboiler# cp sqlboiler /root/
root@517e8bbfecb1:/sqlboiler# cd /root/

root@517e8bbfecb1:~# mkdir templates

root@517e8bbfecb1:~# cat << EOL > templates/99_tablename.go.tpl
> {{- \$alias := .Aliases.Table .Table.Name -}}
>
> // GetTableName returns the real table name.
> func (_ {{\$alias.UpSingular}}) GetTableName() string { return "{{.Table.Name}}" }
> EOL

root@517e8bbfecb1:~# cat templates/99_tablename.go.tpl
{{- $alias := .Aliases.Table .Table.Name -}}

// GetTableName returns the real table name.
func (_ {{$alias.UpSingular}}) GetTableName() string { return "{{.Table.Name}}" }
```

Execution:

```bash
root@517e8bbfecb1:~# ./sqlboiler
Error: must provide a driver name

SQL Boiler generates a Go ORM from template files, tailored to your database schema.
Complete documentation is available at http://github.com/volatiletech/sqlboiler

Usage:
  sqlboiler [flags] <driver>

Examples:
sqlboiler psql

Flags:
      --add-global-variants        Enable generation for global variants
      --add-panic-variants         Enable generation for panic variants
      --add-soft-deletes           Enable soft deletion by updating deleted_at timestamp
  -c, --config string              Filename of config file to override default lookup
  -d, --debug                      Debug mode prints stack traces on error
      --extra-templates strings    The additional templates directory, that does not override the bindata's template folders in sqlboiler
  -h, --help                       help for sqlboiler
      --no-auto-timestamps         Disable automatic timestamps for created_at/updated_at
      --no-back-referencing        Disable back referencing in the loaded relationship structs
      --no-context                 Disable context.Context usage in the generated code
      --no-driver-templates        Disable parsing of templates defined by the database driver
      --no-hooks                   Disable hooks feature for your models
      --no-rows-affected           Disable rows affected in the generated API
      --no-tests                   Disable generated go test files
  -o, --output string              The name of the folder to output to (default "models")
  -p, --pkgname string             The name you wish to assign to your generated package (default "models")
  -r, --relation-tag string        Relationship struct tag name (default "-")
      --struct-tag-casing string   Decides the casing for go structure tag names. camel, title or snake (default snake) (default "snake")
  -t, --tag strings                Struct tags to be included on your models in addition to json, yaml, toml
      --tag-ignore strings         List of column names that should have tags values set to '-' (ignored during parsing)
      --templates strings          A templates directory, overrides the bindata'd template folders in sqlboiler
      --version                    Print the version
      --wipe                       Delete the output folder (rm -rf) before generation to ensure sanity

root@517e8bbfecb1:~# ./sqlboiler mysql --output models_mysql --pkgname models_mysql --wipe --extra-templates ./templates/

root@517e8bbfecb1:~# tail models_mysql/jets.go  -n20
        var exists bool
        sql := "select exists(select 1 from `jets` where `id`=? limit 1)"

        if boil.IsDebug(ctx) {
                writer := boil.DebugWriterFrom(ctx)
                fmt.Fprintln(writer, sql)
                fmt.Fprintln(writer, iD)
        }
        row := exec.QueryRowContext(ctx, sql, iD)

        err := row.Scan(&exists)
        if err != nil {
                return false, errors.Wrap(err, "models_mysql: unable to check if jets exists")
        }

        return exists, nil
}

// GetTableName returns the real table name.
func (_ Jet) GetTableName() string { return "jets" }
```