### PR TITLE
Increased control over ssl-mode in MySQL driver

### DIFF
--- a/drivers/sqlboiler-mysql/driver/override/templates_test/singleton/mysql_main_test.go.tpl
+++ b/drivers/sqlboiler-mysql/driver/override/templates_test/singleton/mysql_main_test.go.tpl
@@ -108,8 +108,10 @@ func (m *mysqlTester) sslMode(mode string) string {
 		return "REQUIRED"
 	case "false":
 		return "DISABLED"
+	case "PREFERRED":
+		return ""
 	default:
-		return "PREFERRED"
+		return mode
 	}
 }
 
@@ -138,7 +140,9 @@ func (m *mysqlTester) makeOptionFile() error {
 	if len(m.pass) != 0 {
 		fmt.Fprintf(tmp, "password=%s\n", m.pass)
 	}
-	fmt.Fprintf(tmp, "ssl-mode=%s\n", m.sslMode(m.sslmode))
+	if mode := m.sslMode(m.sslmode); mode != "" {
+		fmt.Fprintf(tmp, "ssl-mode=%s\n")
+	}
 	if isTCP {
 		fmt.Fprintln(tmp, "protocol=tcp")
 	}
@@ -150,7 +154,9 @@ func (m *mysqlTester) makeOptionFile() error {
 	if len(m.pass) != 0 {
 		fmt.Fprintf(tmp, "password=%s\n", m.pass)
 	}
-	fmt.Fprintf(tmp, "ssl-mode=%s\n", m.sslMode(m.sslmode))
+	if mode := m.sslMode(m.sslmode); mode != "" {
+		fmt.Fprintf(tmp, "ssl-mode=%s\n")
+	}
 	if isTCP {
 		fmt.Fprintln(tmp, "protocol=tcp")
 	}


### PR DESCRIPTION
This works around #273 by improving control over the generated `ssl-mode` flag.

Previously, there were three options:
- Specify `true` in your config file, which resulted in `ssl-mode=REQUIRED`
- Specify `false` in your config file, which resulted in `ssl-mode=DISABLED`
- Specify anything else in your config file, which resulted in `ssl-mode=PREFERRED`
- Leave your config file blank, which Viper would default to `true` and therefore `ssl-mode=REQUIRED`

Now the driver allows directly specifying `REQUIRED`, `DISABLED`, or other previously unavailable options such as `VERIFY_CA` or `VERIFY_IDENTITY`.  The legacy values `true` and `false` still work the same as they did before.

The value `PREFERRED` is specially treated by omitting the `ssl-mode` setting entirely.  This is fine because `PREFERRED` is the default, so the behavior is equivalent.  As a side effect, using `PREFERRED` is a workaround for MariaDB compatibility until https://jira.mariadb.org/browse/MDEV-22129 is handled.

-------------------

This seemed like the best way to go about this because:
- It's backwards compatible.
- It increases the range of options.
- It gives an option for MariaDB users to run tests without editing the generated files.