### PR TITLE
Additional fix for MySQL soft delete code generation

### DIFF
--- a/templates/18_delete.go.tpl
+++ b/templates/18_delete.go.tpl
@@ -273,7 +273,7 @@ func (o {{$alias.UpSingular}}Slice) DeleteAll({{if .NoContext}}exec boil.Executo
 		}
 		wl := []string{"deleted_at"}
 		sql = fmt.Sprintf("UPDATE {{$schemaTable}} SET %s WHERE " +
-			strmangle.WhereClauseRepeated(string(dialect.LQ), string(dialect.RQ), {{if .Dialect.UseIndexPlaceholders}}2{{else}}1{{end}}, {{$alias.DownSingular}}PrimaryKeyColumns, len(o)),
+			strmangle.WhereClauseRepeated(string(dialect.LQ), string(dialect.RQ), {{if .Dialect.UseIndexPlaceholders}}2{{else}}0{{end}}, {{$alias.DownSingular}}PrimaryKeyColumns, len(o)),
 			strmangle.SetParamNames("{{.LQ}}", "{{.RQ}}", {{if .Dialect.UseIndexPlaceholders}}1{{else}}0{{end}}, wl),
 		)
 		args = append([]interface{}{currTime}, args...)


### PR DESCRIPTION
First of all, I'd like to thank you for your hard work.
I've just begun working on a project using SQLBoiler but its ease of use made me love it already.

This PR addresses an issue that was supposed to have been fixed in v4.1.2.
Even after upgrading to v4.1.2, applications using RDBMS such as MySQL are still affected by the issue since DeleteAll code generated for model slices remains to suffer from the very problem (partially) addressed by <https://github.com/volatiletech/sqlboiler/commit/e7b6e07c3d0de5d1ead51192db29fc9880016e35>.

Since the fix mentioned above apparently didn't have an accompanying test or something, I didn't try to guarantee that this fix works. (TBH, I have no idea how.)

### Preconditions

- Soft deletes are enabled via configuration (`add-soft-deletes`).
- There's at least one table that is [capable of soft deletion](https://github.com/volatiletech/sqlboiler/blob/50beb2f5634a449d07cdb2fe7ee2638f08b6be65/drivers/table.go#L68-L75).
- Using an RDBMS whose database driver doesn't `UseIndexPlaceholders`.

### Expected behavior

Generated code should not produce SQL containing placeholders like `$1`.

### Actual behavior

Generated test fails with message like following:
``` 
--- FAIL: TestSliceSoftDeleteAll (0.00s)
    --- FAIL: TestSliceSoftDeleteAll/Products (0.00s)
        product_test.go:120: db: unable to delete all from product slice: Error 1054: Unknown column '$1' in 'where clause'
        product_test.go:131: want zero records, got: 1
```

