### PR TITLE
fix the foreign key name

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ we see it in the code for our domain. Note the use of the foreign key name to
 refer to the relationship in the configuration key.
 
 ```toml
-[aliases.tables.videos.relationships.videos_author_id_fkey]
+[aliases.tables.videos.relationships.videos_user_id_fkey]
 # The local side would originally be inferred as AuthorVideos, which
 # is probably good enough to not want to mess around with this feature, avoid it where possible.
 local   = "AuthoredVideos"


### PR DESCRIPTION
Based on the naming in line `558`, it seems that the key name in line `576` 
must be changed to `videos_user_id_fkey` from `videos_author_id_fkey`