### PR TITLE
Prevent blacklist and whitelist set via ENVs from being converted int…

### DIFF
--- a/main.go
+++ b/main.go
@@ -204,8 +204,10 @@ func preRun(cmd *cobra.Command, args []string) error {
 
 	keys := allKeys(driverName)
 	for _, key := range keys {
-		prefixedKey := fmt.Sprintf("%s.%s", driverName, key)
-		cmdConfig.DriverConfig[key] = viper.Get(prefixedKey)
+		if key != "blacklist" && key != "whitelist" {
+			prefixedKey := fmt.Sprintf("%s.%s", driverName, key)
+			cmdConfig.DriverConfig[key] = viper.Get(prefixedKey)
+		}
 	}
 
 	cmdConfig.Imports = configureImports()


### PR DESCRIPTION
Hi,
First of all thanks for the project. Really appreciate it.

As for the PR, I came across this issue when I tried to generate the models inside a container. I replicated the issue by setting the values in `~/.zshenv`(for bash it would be `~/.bash_profile`)  -> `export PSQL_BLACKLIST=schema_migrations` and ran sqlboiler which generated the `schema_migrations` model.

My current workaround is having the sqlboiler.toml file as 
```
[psql]
  blacklist = ["schema_migrations"]
```
and **NOT** setting the PSQL_BLACKLIST env value

**NOTE**: If I set both the env and the sqlboiler.toml file values, the envs take precedence and the `schema_migrations` model gets generated

Let me know how I can help to get this fix onto master.

Might help to get all envs working with this issue: https://github.com/volatiletech/sqlboiler/issues/678