### PR TITLE
mysql driver support comment tinyint_as_bool

### DIFF
--- a/drivers/column.go
+++ b/drivers/column.go
@@ -16,6 +16,7 @@ type Column struct {
 	Nullable  bool   `json:"nullable" toml:"nullable"`
 	Unique    bool   `json:"unique" toml:"unique"`
 	Validated bool   `json:"validated" toml:"validated"`
+	Comment   string `json:"comment" toml:"comment"`
 
 	// Postgres only extension bits
 	// ArrType is the underlying data type of the Postgres


### PR DESCRIPTION
It is very expensive to change the column type to fit tinyint_as_int feature if a database is not designed for it when it created.

Is use comment of a column a better way to implement this feature?

```SQL
CREATE TABLE `test` (
  `i_am_tinyint` tinyint(3) UNSIGNED NOT NULL DEFAULT '0',
  `i_am_bool` tinyint(3) UNSIGNED NOT NULL DEFAULT '0' COMMENT 'tinyint_as_bool',
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
```