### PR TITLE
fix get table whitelist/blacklist from environment

### DIFF
--- a/main.go
+++ b/main.go
@@ -197,16 +197,15 @@ func preRun(cmd *cobra.Command, args []string) error {
 	}
 
 	// Configure the driver
-	cmdConfig.DriverConfig = map[string]interface{}{
-		"whitelist": viper.GetStringSlice(driverName + ".whitelist"),
-		"blacklist": viper.GetStringSlice(driverName + ".blacklist"),
-	}
-
+	cmdConfig.DriverConfig = map[string]interface{}{}
 	keys := allKeys(driverName)
 	for _, key := range keys {
 		prefixedKey := fmt.Sprintf("%s.%s", driverName, key)
 		cmdConfig.DriverConfig[key] = viper.Get(prefixedKey)
 	}
+	// Key requires method other than viper.Get should be placed here.
+	cmdConfig.DriverConfig["whitelist"] = viper.GetStringSlice(driverName + ".whitelist")
+	cmdConfig.DriverConfig["blacklist"] = viper.GetStringSlice(driverName + ".blacklist")
 
 	cmdConfig.Imports = configureImports()
 


### PR DESCRIPTION
This PR fix an issue that ${driver}_whitelist configured from environment would be ignored.

Example:

set whitelist:
```
export MYSQL_WHITELIST="table_a table_b table_c"
```

run sqlboiler
```
DEBUG=true sqlboiler --no-tests --wipe mysql
```

The whitelist config would be parsed to: 
```json
{"config":{"driver_name":"mysql","driver_config":{
...
"whitelist":["table_a table_b table_c"]}
```

which should be: 
```
"whitelist":["table_a", "table_b", "table_c"]}
```