### PR TITLE
Fix NotIn query mods and building.

### DIFF
--- a/queries/qm/query_mods.go
+++ b/queries/qm/query_mods.go
@@ -361,7 +361,7 @@ type whereNotInQueryMod struct {
 
 // Apply implements QueryMod.Apply.
 func (qm whereNotInQueryMod) Apply(q *queries.Query) {
-	queries.AppendIn(q, qm.clause, qm.args...)
+	queries.AppendNotIn(q, qm.clause, qm.args...)
 }
 
 // WhereNotIn allows you to specify a "x NOT IN (set)" clause for your where
@@ -381,7 +381,7 @@ type andNotInQueryMod struct {
 
 // Apply implements QueryMod.Apply.
 func (qm andNotInQueryMod) Apply(q *queries.Query) {
-	queries.AppendIn(q, qm.clause, qm.args...)
+	queries.AppendNotIn(q, qm.clause, qm.args...)
 }
 
 // AndNotIn allows you to specify a "x NOT IN (set)" clause separated by an
@@ -403,7 +403,7 @@ type orNotInQueryMod struct {
 
 // Apply implements QueryMod.Apply.
 func (qm orNotInQueryMod) Apply(q *queries.Query) {
-	queries.AppendIn(q, qm.clause, qm.args...)
+	queries.AppendNotIn(q, qm.clause, qm.args...)
 	queries.SetLastInAsOr(q)
 }
 

--- a/queries/query_builders.go
+++ b/queries/query_builders.go
@@ -11,8 +11,9 @@ import (
 )
 
 var (
-	rgxIdentifier = regexp.MustCompile(`^(?i)"?[a-z_][_a-z0-9]*"?(?:\."?[_a-z][_a-z0-9]*"?)*$`)
-	rgxInClause   = regexp.MustCompile(`^(?i)(.*[\s|\)|\?])IN([\s|\(|\?].*)$`)
+	rgxIdentifier  = regexp.MustCompile(`^(?i)"?[a-z_][_a-z0-9]*"?(?:\."?[_a-z][_a-z0-9]*"?)*$`)
+	rgxInClause    = regexp.MustCompile(`^(?i)(.*[\s|\)|\?])IN([\s|\(|\?].*)$`)
+	rgxNotInClause = regexp.MustCompile(`^(?i)(.*[\s|\)|\?])NOT\s+IN([\s|\(|\?].*)$`)
 )
 
 // BuildQuery builds a query object into the query string
@@ -399,7 +400,14 @@ ManualParen:
 				}
 				break
 			}
-			matches := rgxInClause.FindStringSubmatch(where.clause)
+
+			var matches []string
+			if where.kind == whereKindIn {
+				matches = rgxInClause.FindStringSubmatch(where.clause)
+			} else {
+				matches = rgxNotInClause.FindStringSubmatch(where.clause)
+			}
+
 			// If we can't find any matches attempt a simple replace with 1 group.
 			// Clauses that fit this criteria will not be able to contain ? in their
 			// column name side, however if this case is being hit then the regexp

--- a/queries/query_builders_test.go
+++ b/queries/query_builders_test.go
@@ -328,6 +328,38 @@ func TestWhereClause(t *testing.T) {
 	}
 }
 
+func TestNotInClause(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		q      Query
+		expect string
+		args   []interface{}
+	}{
+		{
+			q: Query{
+				where: []where{{kind: whereKindNotIn, clause: "a not in ?", args: []interface{}{}, orSeparator: true}},
+			},
+			expect: ` WHERE (1=1)`,
+		},
+		{
+			q: Query{
+				where: []where{{kind: whereKindNotIn, clause: "a not in ?", args: []interface{}{1}, orSeparator: true}},
+			},
+			expect: ` WHERE ("a" NOT IN ($1))`,
+			args:   []interface{}{1},
+		},
+	}
+	for i, test := range tests {
+		test.q.dialect = &drivers.Dialect{LQ: '"', RQ: '"', UseIndexPlaceholders: true}
+		result, args := whereClause(&test.q, 1)
+		if result != test.expect {
+			t.Errorf("%d) Mismatch between expect and result:\n%s\n%s\n", i, test.expect, result)
+		}
+		if !reflect.DeepEqual(args, test.args) {
+			t.Errorf("%d) Mismatch between expected args:\n%#v\n%#v\n", i, test.args, args)
+		}
+	}
+}
 func TestInClause(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This PR fixes two problems:
* The `qm.WhereNotIn`, `qm.AndNotIn`, `qm.OrNotIn` helpers were adding `Query` structs with the wrong `kind` because they used the `AppendIn` function instead of the `AppendNotIn`. This presents as a bug where building a not in query with an empty set -- it should be rendered as `(1=1)` (everything is not a member of the empty set) but instead renders as `(1=0)`, as if it were a In query (nothing is a member of the empty set.)
* Queries with `whereKindNotIn` were not rendering appropriately because the regex used to parse their `clause` was the same as the one used for `whereKindIn`. I created a separate regex instead of making the `NOT\s+` optional.

This PR includes tests for the second problem, but none for the first because there are currently no tests for the `qm` package and I wasn't sure the best way to write them. I think the best testing strategy might be to update the query building tests to call the `qm` helpers instead of manually constructing `Query` structs, or at least add some tests that work this way. But that led me to some circular import errors so I figured I'd send the PR without the tests as a starting point.