### PR TITLE
Case-sensitive table name on psql regclass table lookup

### DIFF
--- a/drivers/sqlboiler-psql/driver/psql.go
+++ b/drivers/sqlboiler-psql/driver/psql.go
@@ -207,7 +207,7 @@ func (p *PostgresDriver) Columns(schema, tableName string, whitelist, blacklist 
 		c.domain_name,
 		c.column_default,
 
-		COALESCE(col_description((c.table_schema||'.'||c.table_name)::regclass::oid, ordinal_position), '') as column_comment,
+		COALESCE(col_description(('"'||c.table_schema||'"."'||c.table_name||'"')::regclass::oid, ordinal_position), '') as column_comment,
 
 		c.is_nullable = 'YES' as is_nullable,
 		(case


### PR DESCRIPTION
Fixes: https://github.com/volatiletech/sqlboiler/issues/861

Ref: https://stackoverflow.com/questions/56227815/is-there-a-way-to-use-regclass-in-a-case-sensitive-way