### PR TITLE
Schema predicate for enum generating query

### DIFF
--- a/drivers/sqlboiler-psql/driver/psql.go
+++ b/drivers/sqlboiler-psql/driver/psql.go
@@ -254,7 +254,8 @@ func (p *PostgresDriver) Columns(schema, tableName string, whitelist, blacklist 
 						(
 							select typelem
 							from pg_type
-							where pg_type.typtype = 'b' and pg_type.typname = ('_' || c.udt_name)
+							inner join pg_namespace ON pg_type.typnamespace = pg_namespace.oid
+							where pg_type.typtype = 'b' and pg_type.typname = ('_' || c.udt_name) and pg_namespace.nspname=$1
 							limit 1
 						)
 						order by pg_enum.enumsortorder


### PR DESCRIPTION
Fix for #881 

There's no predicate for the pg_type sub-query to only look at the schema being used in generation, I am not exactly sure if this is 100% correct fix as you could want to use an enum from another schema but this is just to get the ball rolling and I am happy to provide test coverage for this change but I first wanted some early feedback on my suggested fix.
