### PR TITLE
Avoid allocation in JSON.Scan with string

### DIFF
--- a/types/json.go
+++ b/types/json.go
@@ -62,20 +62,16 @@ func (j JSON) Value() (driver.Value, error) {
 
 // Scan stores the src in *j.
 func (j *JSON) Scan(src interface{}) error {
-	var source []byte
-
-	switch src.(type) {
+	switch source := src.(type) {
 	case string:
-		source = []byte(src.(string))
+		*j = append((*j)[0:0], source...)
+		return nil
 	case []byte:
-		source = src.([]byte)
+		*j = append((*j)[0:0], source...)
+		return nil
 	default:
 		return errors.New("incompatible type for json")
 	}
-
-	*j = JSON(append((*j)[0:0], source...))
-
-	return nil
 }
 
 // Randomize for sqlboiler

--- a/types/json_test.go
+++ b/types/json_test.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 )
 
@@ -115,5 +116,16 @@ func TestJSONScan(t *testing.T) {
 
 	if !bytes.Equal(j, []byte(`"hello"`)) {
 		t.Errorf("bad []byte: %#v ≠ %#v\n", j, string([]byte(`"hello"`)))
+	}
+}
+
+func BenchmarkJSON_Scan(b *testing.B) {
+	data := `"` + strings.Repeat("A", 1024) + `"`
+	for i := 0; i < b.N; i++ {
+		var j JSON
+		err := j.Scan(data)
+		if err != nil {
+			b.Error(err)
+		}
 	}
 }


### PR DESCRIPTION
`[]byte(src.(string))` is an unneeded allocation, because you can splat a string directly into an append call.

Benchmark:

```
$ go test -benchmem -bench=JSON

# Before

goos: darwin
goarch: arm64
pkg: github.com/volatiletech/sqlboiler/v4/types
BenchmarkJSON_Scan-8   	 4658832	       237.9 ns/op	    2304 B/op	       2 allocs/op
PASS
ok  	github.com/volatiletech/sqlboiler/v4/types	1.738s

# After

goos: darwin
goarch: arm64
pkg: github.com/volatiletech/sqlboiler/v4/types
BenchmarkJSON_Scan-8   	 8657862	       118.0 ns/op	    1152 B/op	       1 allocs/op
PASS
ok  	github.com/volatiletech/sqlboiler/v4/types	1.435s
```