### PR TITLE
Fix panic message from queries.Assign()

### DIFF
--- a/queries/reflect.go
+++ b/queries/reflect.go
@@ -566,7 +566,7 @@ func Assign(dst, src interface{}) {
 		src = upgradeNumericTypes(src)
 
 		if err := scan.Scan(src); err != nil {
-			panic(fmt.Sprintf("tried to call Scan on %T with %#v but got err: %+v", dst, val, err))
+			panic(fmt.Sprintf("tried to call Scan on %T with %#v but got err: %+v", dst, src, err))
 		}
 
 	case !isDstScanner && isSrcValuer:


### PR DESCRIPTION
While digging into #905, I've found that the panic message is incorrect. If we in the case of `isDstScanner && !isSrcValuer`, `val` is always nil, so the message will be `tried to call Scan on *null.Uint64 with <nil> but got err: ...` for example.

I've fixed the message to contain `val`, like panic says `tried to call Scan on *null.Uint64 with -9223372036854775808 but got err: ...` for example.