### PR TITLE
Fix queries.Equal() not to panic when comparing null.Uint64 and uint64

### DIFF
--- a/queries/reflect.go
+++ b/queries/reflect.go
@@ -7,6 +7,7 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -514,6 +515,14 @@ func Equal(a, b interface{}) bool {
 		return false
 	}
 
+	// If either is string and another is numeric, try to parse string as numeric
+	if as, ok := a.(string); ok && isNumeric(b) {
+		a = parseNumeric(as, reflect.TypeOf(b))
+	}
+	if bs, ok := b.(string); ok && isNumeric(a) {
+		b = parseNumeric(bs, reflect.TypeOf(a))
+	}
+
 	a = upgradeNumericTypes(a)
 	b = upgradeNumericTypes(b)
 
@@ -531,6 +540,56 @@ func Equal(a, b interface{}) bool {
 	}
 
 	return false
+}
+
+// isNumeric tests if i is a numeric value.
+func isNumeric(i interface{}) bool {
+	switch i.(type) {
+	case int,
+		int8,
+		int16,
+		int32,
+		int64,
+		uint,
+		uint8,
+		uint16,
+		uint32,
+		uint64,
+		float32,
+		float64:
+		return true
+	}
+	return false
+}
+
+// parseNumeric tries to parse s as t.
+// t must be a numeric type.
+func parseNumeric(s string, t reflect.Type) interface{} {
+	var (
+		res interface{}
+		err error
+	)
+	switch t.Kind() {
+	case reflect.Int,
+		reflect.Int8,
+		reflect.Int16,
+		reflect.Int32,
+		reflect.Int64:
+		res, err = strconv.ParseInt(s, 0, t.Bits())
+	case reflect.Uint,
+		reflect.Uint8,
+		reflect.Uint16,
+		reflect.Uint32,
+		reflect.Uint64:
+		res, err = strconv.ParseUint(s, 0, t.Bits())
+	case reflect.Float32,
+		reflect.Float64:
+		res, err = strconv.ParseFloat(s, t.Bits())
+	}
+	if err != nil {
+		panic(fmt.Sprintf("tries to parse %q as %s but got error: %+v", s, t.String(), err))
+	}
+	return res
 }
 
 // Assign assigns a value to another using reflection.

--- a/queries/reflect_test.go
+++ b/queries/reflect_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/volatiletech/sqlboiler/v4/drivers"
+	"github.com/volatiletech/null/v8"
 
 	"github.com/DATA-DOG/go-sqlmock"
 )
@@ -607,6 +608,8 @@ func TestEqual(t *testing.T) {
 		{A: "hello", B: sql.NullString{Valid: false}, Want: false},
 		{A: now, B: now, Want: true},
 		{A: now, B: now.Add(time.Hour), Want: false},
+		{A: null.Uint64From(uint64(9223372036854775808)), B: uint64(9223372036854775808), Want: true},
+		{A: null.Uint64From(uint64(9223372036854775808)), B: uint64(9223372036854775809), Want: false},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
As proposed in #905, I've fixed `queries.Equal()` to format given number to string when one is a number and another is a string after pulled a primitive value from `driver.Valuer`.

This will fix part of #905. (Eager loading panics)

I believe this will not break backward compatibility, but I'm not sure if there are some corner cases.

This PR won't change the behavior of the function when passing pairs, except for a number, and a value which finally becomes a string. In most cases, comparison with string and number won't happen. 

For affected cases, if the given string cannot be parsed as a number, a panic will raise from `parseNumeric()`. But for this situation, panic will be raised in the current dev branch too, so from the point of library users, the behavior seems to be unchanged almost.