### PR TITLE
Add always-wrap-errors flag

### DIFF
--- a/boilingcore/boilingcore.go
+++ b/boilingcore/boilingcore.go
@@ -140,6 +140,7 @@ func (s *State) Run() error {
 		NoRowsAffected:    s.Config.NoRowsAffected,
 		NoDriverTemplates: s.Config.NoDriverTemplates,
 		NoBackReferencing: s.Config.NoBackReferencing,
+		AlwaysWrapErrors:  s.Config.AlwaysWrapErrors,
 		StructTagCasing:   s.Config.StructTagCasing,
 		TagIgnore:         make(map[string]struct{}),
 		Tags:              s.Config.Tags,

--- a/boilingcore/config.go
+++ b/boilingcore/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	NoRowsAffected    bool     `toml:"no_rows_affected,omitempty" json:"no_rows_affected,omitempty"`
 	NoDriverTemplates bool     `toml:"no_driver_templates,omitempty" json:"no_driver_templates,omitempty"`
 	NoBackReferencing bool     `toml:"no_back_reference,omitempty" json:"no_back_reference,omitempty"`
+	AlwaysWrapErrors  bool     `toml:"always_wrap_errors,omitempty" json:"always_wrap_errors,omitempty"`
 	Wipe              bool     `toml:"wipe,omitempty" json:"wipe,omitempty"`
 	StructTagCasing   string   `toml:"struct_tag_casing,omitempty" json:"struct_tag_casing,omitempty"`
 	RelationTag       string   `toml:"relation_tag,omitempty" json:"relation_tag,omitempty"`

--- a/boilingcore/templates.go
+++ b/boilingcore/templates.go
@@ -47,6 +47,7 @@ type templateData struct {
 	NoRowsAffected    bool
 	NoDriverTemplates bool
 	NoBackReferencing bool
+	AlwaysWrapErrors  bool
 
 	// Tags control which tags are added to the struct
 	Tags []string

--- a/main.go
+++ b/main.go
@@ -101,6 +101,7 @@ func main() {
 	rootCmd.PersistentFlags().BoolP("no-auto-timestamps", "", false, "Disable automatic timestamps for created_at/updated_at")
 	rootCmd.PersistentFlags().BoolP("no-driver-templates", "", false, "Disable parsing of templates defined by the database driver")
 	rootCmd.PersistentFlags().BoolP("no-back-referencing", "", false, "Disable back referencing in the loaded relationship structs")
+	rootCmd.PersistentFlags().BoolP("always-wrap-errors", "", false, "Wrap all returned errors with stacktraces, also sql.ErrNoRows")
 	rootCmd.PersistentFlags().BoolP("add-global-variants", "", false, "Enable generation for global variants")
 	rootCmd.PersistentFlags().BoolP("add-panic-variants", "", false, "Enable generation for panic variants")
 	rootCmd.PersistentFlags().BoolP("add-soft-deletes", "", false, "Enable soft deletion by updating deleted_at timestamp")
@@ -180,6 +181,7 @@ func preRun(cmd *cobra.Command, args []string) error {
 		NoAutoTimestamps:  viper.GetBool("no-auto-timestamps"),
 		NoDriverTemplates: viper.GetBool("no-driver-templates"),
 		NoBackReferencing: viper.GetBool("no-back-referencing"),
+		AlwaysWrapErrors:  viper.GetBool("always-wrap-errors"),
 		Wipe:              viper.GetBool("wipe"),
 		StructTagCasing:   strings.ToLower(viper.GetString("struct-tag-casing")), // camel | snake | title
 		TagIgnore:         viper.GetStringSlice("tag-ignore"),

--- a/templates/main/03_finishers.go.tpl
+++ b/templates/main/03_finishers.go.tpl
@@ -42,9 +42,11 @@ func (q {{$alias.DownSingular}}Query) One({{if .NoContext}}exec boil.Executor{{e
 
 	err := q.Bind({{if .NoContext}}nil{{else}}ctx{{end}}, exec, o)
 	if err != nil {
+		{{if not .AlwaysWrapErrors -}}
 		if errors.Cause(err) == sql.ErrNoRows {
 			return nil, sql.ErrNoRows
 		}
+		{{end -}}
 		return nil, errors.Wrap(err, "{{.PkgName}}: failed to execute a one query for {{.Table.Name}}")
 	}
 

--- a/templates/main/14_find.go.tpl
+++ b/templates/main/14_find.go.tpl
@@ -54,9 +54,11 @@ func Find{{$alias.UpSingular}}({{if .NoContext}}exec boil.Executor{{else}}ctx co
 
 	err := q.Bind({{if not .NoContext}}ctx{{else}}nil{{end}}, exec, {{$alias.DownSingular}}Obj)
 	if err != nil {
+		{{if not .AlwaysWrapErrors -}}
 		if errors.Cause(err) == sql.ErrNoRows {
 			return nil, sql.ErrNoRows
 		}
+		{{end -}}
 		return nil, errors.Wrap(err, "{{.PkgName}}: unable to select from {{.Table.Name}}")
 	}
 


### PR DESCRIPTION
Currently all methods on models except for `Model.One(...)` and `FindModel(...)` always return wrapped errors with stacktraces. If no rows are returned `Model.One(...)` and `FindModel(...)` unwrap the returned error and return `sql.ErrNoRows` without  a stacktrace.

This PR adds an option, `always-wrap-errors` that disables this unwrapping. Comparing wrapped errors is supported in the standard library with `errors.Is(err, sql.ErrNoRows)`, and e.g. in our codebase we have a linter that doesn't allow direct equality checks when comparing errors (`err == sql.ErrNoRows`).

This PR doesn't include any additional tests, there doesn't seem to be tests for individual flags (correct me if I'm wrong). The test-suite passes locally with the flag enabled

Previously opened this PR against the master branch #955 - new try against dev here