### PR TITLE
Fix forgetting to call rows.Close

### DIFF
--- a/drivers/sqlboiler-mssql/driver/mssql.go
+++ b/drivers/sqlboiler-mssql/driver/mssql.go
@@ -352,6 +352,7 @@ func (m *MSSQLDriver) ForeignKeyInfo(schema, tableName string) ([]drivers.Foreig
 	if rows, err = m.conn.Query(query, schema, schema, tableName); err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 
 	for rows.Next() {
 		var fkey drivers.ForeignKey

--- a/drivers/sqlboiler-mysql/driver/mysql.go
+++ b/drivers/sqlboiler-mysql/driver/mysql.go
@@ -331,6 +331,7 @@ func (m *MySQLDriver) ForeignKeyInfo(schema, tableName string) ([]drivers.Foreig
 	if rows, err = m.conn.Query(query, schema, schema, tableName); err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 
 	for rows.Next() {
 		var fkey drivers.ForeignKey

--- a/drivers/sqlboiler-psql/driver/psql.go
+++ b/drivers/sqlboiler-psql/driver/psql.go
@@ -416,6 +416,7 @@ func (p *PostgresDriver) ForeignKeyInfo(schema, tableName string) ([]drivers.For
 	if rows, err = p.conn.Query(query, tableName, schema); err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 
 	for rows.Next() {
 		var fkey drivers.ForeignKey


### PR DESCRIPTION
i found rows.Close is not called in ForeignKeyInfo function.