### PR TITLE
Support sqlcommenter comments

### DIFF
--- a/queries/query.go
+++ b/queries/query.go
@@ -30,22 +30,23 @@ type Query struct {
 	load     []string
 	loadMods map[string]Applicator
 
-	delete     bool
-	update     map[string]interface{}
-	withs      []argClause
-	selectCols []string
-	count      bool
-	from       []string
-	joins      []join
-	where      []where
-	groupBy    []string
-	orderBy    []argClause
-	having     []argClause
-	limit      *int
-	offset     int
-	forlock    string
-	distinct   string
-	comment    string
+	delete        bool
+	update        map[string]interface{}
+	withs         []argClause
+	selectCols    []string
+	count         bool
+	from          []string
+	joins         []join
+	where         []where
+	groupBy       []string
+	orderBy       []argClause
+	having        []argClause
+	limit         *int
+	offset        int
+	forlock       string
+	distinct      string
+	comment       string
+	appendComment string
 
 	// This field is a hack to allow a query to strip out the reference
 	// to deleted at is null.
@@ -279,6 +280,11 @@ func SetFor(q *Query, clause string) {
 // SetComment on the query.
 func SetComment(q *Query, comment string) {
 	q.comment = comment
+}
+
+// SetAppendComment on the query.
+func SetAppendComment(q *Query, appendComment string) {
+	q.appendComment = appendComment
 }
 
 // SetUpdate on the query.

--- a/queries/query_builders.go
+++ b/queries/query_builders.go
@@ -134,6 +134,9 @@ func buildSelectQuery(q *Query) (*bytes.Buffer, []interface{}) {
 	writeModifiers(q, buf, &args)
 
 	buf.WriteByte(';')
+
+	writeAppendComment(q, buf)
+
 	return buf, args
 }
 
@@ -156,6 +159,8 @@ func buildDeleteQuery(q *Query) (*bytes.Buffer, []interface{}) {
 	writeModifiers(q, buf, &args)
 
 	buf.WriteByte(';')
+
+	writeAppendComment(q, buf)
 
 	return buf, args
 }
@@ -200,6 +205,8 @@ func buildUpdateQuery(q *Query) (*bytes.Buffer, []interface{}) {
 	writeModifiers(q, buf, &args)
 
 	buf.WriteByte(';')
+
+	writeAppendComment(q, buf)
 
 	return buf, args
 }
@@ -602,6 +609,16 @@ func writeComment(q *Query, buf *bytes.Buffer) {
 		buf.WriteString(line)
 		buf.WriteByte('\n')
 	}
+}
+
+func writeAppendComment(q *Query, buf *bytes.Buffer) {
+	if len(q.appendComment) == 0 {
+		return
+	}
+
+	buf.WriteString(" /* ")
+	buf.WriteString(q.appendComment)
+	buf.WriteString(" */ ")
 }
 
 func writeCTEs(q *Query, buf *bytes.Buffer, args *[]interface{}) {

--- a/queries/query_test.go
+++ b/queries/query_test.go
@@ -654,6 +654,17 @@ func TestSetComment(t *testing.T) {
 	}
 }
 
+func TestSetAppendComment(t *testing.T) {
+	t.Parallel()
+
+	q := &Query{}
+	SetAppendComment(q, "my comment")
+
+	if q.appendComment != "my comment" {
+		t.Errorf("Got invalid comment: %s", q.appendComment)
+	}
+}
+
 func TestRemoveSoftDeleteWhere(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
https://google.github.io/sqlcommenter/ makes it possible to add tracing comments that can be interpreted by e.g. GCPs query analyser.

https://github.com/volatiletech/sqlboiler/pull/872 added support for comments but they are prepended on a separate line and sqlcommenter requires the form `/* … */` to be added on the same line as the query which is why I’ve added this PR and the `qm.AppendComment` function.

For example:
```
q := shop.Customers(
  qm.AppendComment("shop.getAllCustomers"),
  qm.Select("id", "name"),
  qm.From("customers"),
)
```
will be:
```
SELECT id, name FROM customers; /* shop.getAllCustomers /*
```