### PR TITLE
Adding Debug Formatter function and Query duration to debug info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [v4.6.0] - 2021-06-06
 
 ### Added
 

--- a/boil/debug.go
+++ b/boil/debug.go
@@ -2,8 +2,10 @@ package boil
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
+	"time"
 )
 
 // DebugMode is a flag controlling whether generated sql statements and
@@ -14,6 +16,13 @@ var DebugMode = false
 
 // DebugWriter is where the debug output will be sent if DebugMode is true
 var DebugWriter io.Writer = os.Stdout
+
+// DebugFormatter formats query and args
+var DebugFormatter = func(writer io.Writer, query string, args []interface{}, duration time.Duration) {
+	fmt.Fprintln(writer, query)
+	fmt.Fprintln(writer, args)
+	fmt.Fprintln(writer, duration)
+}
 
 // WithDebug modifies a context to configure debug writing. If true,
 // all queries made using this context will be outputted to the io.Writer

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 
 //go:generate go-bindata -nometadata -pkg templatebin -o templatebin/bindata.go templates templates/singleton templates_test templates_test/singleton
 
-const sqlBoilerVersion = "4.5.0"
+const sqlBoilerVersion = "4.6.0"
 
 var (
 	flagConfigFile string

--- a/queries/query.go
+++ b/queries/query.go
@@ -3,8 +3,8 @@ package queries
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"regexp"
+	"time"
 
 	"github.com/volatiletech/sqlboiler/v4/boil"
 	"github.com/volatiletech/sqlboiler/v4/drivers"
@@ -117,64 +117,88 @@ func RawG(query string, args ...interface{}) *Query {
 // Exec executes a query that does not need a row returned
 func (q *Query) Exec(exec boil.Executor) (sql.Result, error) {
 	qs, args := BuildQuery(q)
+	before := time.Now()
+	res, err := exec.Exec(qs, args...)
+
 	if boil.DebugMode {
-		fmt.Fprintln(boil.DebugWriter, qs)
-		fmt.Fprintln(boil.DebugWriter, args)
+		after := time.Now()
+		duration := after.Sub(before)
+		boil.DebugFormatter(boil.DebugWriter, qs, args, duration)
 	}
-	return exec.Exec(qs, args...)
+	return res, err
 }
 
 // QueryRow executes the query for the One finisher and returns a row
 func (q *Query) QueryRow(exec boil.Executor) *sql.Row {
 	qs, args := BuildQuery(q)
+	before := time.Now()
+	row := exec.QueryRow(qs, args...)
+
 	if boil.DebugMode {
-		fmt.Fprintln(boil.DebugWriter, qs)
-		fmt.Fprintln(boil.DebugWriter, args)
+		after := time.Now()
+		duration := after.Sub(before)
+		boil.DebugFormatter(boil.DebugWriter, qs, args, duration)
 	}
-	return exec.QueryRow(qs, args...)
+	return row
 }
 
 // Query executes the query for the All finisher and returns multiple rows
 func (q *Query) Query(exec boil.Executor) (*sql.Rows, error) {
 	qs, args := BuildQuery(q)
+	before := time.Now()
+	rows, err := exec.Query(qs, args...)
+
 	if boil.DebugMode {
-		fmt.Fprintln(boil.DebugWriter, qs)
-		fmt.Fprintln(boil.DebugWriter, args)
+		after := time.Now()
+		duration := after.Sub(before)
+		boil.DebugFormatter(boil.DebugWriter, qs, args, duration)
 	}
-	return exec.Query(qs, args...)
+	return rows, err
 }
 
 // ExecContext executes a query that does not need a row returned
 func (q *Query) ExecContext(ctx context.Context, exec boil.ContextExecutor) (sql.Result, error) {
 	qs, args := BuildQuery(q)
+	before := time.Now()
+	res, err := exec.ExecContext(ctx, qs, args...)
+
 	if boil.IsDebug(ctx) {
+		after := time.Now()
+		duration := after.Sub(before)
 		writer := boil.DebugWriterFrom(ctx)
-		fmt.Fprintln(writer, qs)
-		fmt.Fprintln(writer, args)
+		boil.DebugFormatter(writer, qs, args, duration)
 	}
-	return exec.ExecContext(ctx, qs, args...)
+	return res, err
 }
 
 // QueryRowContext executes the query for the One finisher and returns a row
 func (q *Query) QueryRowContext(ctx context.Context, exec boil.ContextExecutor) *sql.Row {
 	qs, args := BuildQuery(q)
+	before := time.Now()
+	row := exec.QueryRowContext(ctx, qs, args...)
+
 	if boil.IsDebug(ctx) {
+		after := time.Now()
+		duration := after.Sub(before)
 		writer := boil.DebugWriterFrom(ctx)
-		fmt.Fprintln(writer, qs)
-		fmt.Fprintln(writer, args)
+		boil.DebugFormatter(writer, qs, args, duration)
 	}
-	return exec.QueryRowContext(ctx, qs, args...)
+	return row
 }
 
 // QueryContext executes the query for the All finisher and returns multiple rows
 func (q *Query) QueryContext(ctx context.Context, exec boil.ContextExecutor) (*sql.Rows, error) {
 	qs, args := BuildQuery(q)
+	before := time.Now()
+	rows, err := exec.QueryContext(ctx, qs, args...)
+	
 	if boil.IsDebug(ctx) {
+		after := time.Now()
+		duration := after.Sub(before)
 		writer := boil.DebugWriterFrom(ctx)
-		fmt.Fprintln(writer, qs)
-		fmt.Fprintln(writer, args)
+		boil.DebugFormatter(writer, qs, args, duration)
 	}
-	return exec.QueryContext(ctx, qs, args...)
+	return rows, err
 }
 
 // ExecP executes a query that does not need a row returned


### PR DESCRIPTION
Adding debug formatter function makes sqlboiler more extensible and lets users to more customizable debug logs

Query duration will be useful during performance improvement