### PR TITLE
fix bug with soft deletes and custom auto-columns

### DIFF
--- a/drivers/table.go
+++ b/drivers/table.go
@@ -65,9 +65,13 @@ func (t Table) CanLastInsertID() bool {
 	return true
 }
 
-func (t Table) CanSoftDelete() bool {
+func (t Table) CanSoftDelete(deleteColumn string) bool {
+	if deleteColumn == "" {
+		deleteColumn = "deleted_at"
+	}
+
 	for _, column := range t.Columns {
-		if column.Name == "deleted_at" && column.Type == "null.Time" {
+		if column.Name == deleteColumn && column.Type == "null.Time" {
 			return true
 		}
 	}

--- a/drivers/table_test.go
+++ b/drivers/table_test.go
@@ -143,7 +143,7 @@ func TestCanSoftDelete(t *testing.T) {
 			Columns: test.Columns,
 		}
 
-		if got := table.CanSoftDelete(); got != test.Can {
+		if got := table.CanSoftDelete("deleted_at"); got != test.Can {
 			t.Errorf("%d) wrong: %t", i, got)
 		}
 	}

--- a/templates/main/04_relationship_to_one.go.tpl
+++ b/templates/main/04_relationship_to_one.go.tpl
@@ -4,7 +4,7 @@
 		{{- $ltable := $.Aliases.Table $fkey.Table -}}
 		{{- $ftable := $.Aliases.Table $fkey.ForeignTable -}}
 		{{- $rel := $ltable.Relationship $fkey.Name -}}
-		{{- $canSoftDelete := (getTable $.Tables $fkey.ForeignTable).CanSoftDelete }}
+		{{- $canSoftDelete := (getTable $.Tables $fkey.ForeignTable).CanSoftDelete $.AutoColumns.Deleted }}
 // {{$rel.Foreign}} pointed to by the foreign key.
 func (o *{{$ltable.UpSingular}}) {{$rel.Foreign}}(mods ...qm.QueryMod) ({{$ftable.DownSingular}}Query) {
 	queryMods := []qm.QueryMod{

--- a/templates/main/05_relationship_one_to_one.go.tpl
+++ b/templates/main/05_relationship_one_to_one.go.tpl
@@ -4,7 +4,7 @@
 		{{- $ltable := $.Aliases.Table $rel.Table -}}
 		{{- $ftable := $.Aliases.Table $rel.ForeignTable -}}
 		{{- $relAlias := $ftable.Relationship $rel.Name -}}
-		{{- $canSoftDelete := (getTable $.Tables $rel.ForeignTable).CanSoftDelete }}
+		{{- $canSoftDelete := (getTable $.Tables $rel.ForeignTable).CanSoftDelete $.AutoColumns.Deleted }}
 // {{$relAlias.Local}} pointed to by the foreign key.
 func (o *{{$ltable.UpSingular}}) {{$relAlias.Local}}(mods ...qm.QueryMod) ({{$ftable.DownSingular}}Query) {
 	queryMods := []qm.QueryMod{

--- a/templates/main/06_relationship_to_many.go.tpl
+++ b/templates/main/06_relationship_to_many.go.tpl
@@ -5,7 +5,7 @@
 		{{- $ftable := $.Aliases.Table $rel.ForeignTable -}}
 		{{- $relAlias := $.Aliases.ManyRelationship $rel.ForeignTable $rel.Name $rel.JoinTable $rel.JoinLocalFKeyName -}}
 		{{- $schemaForeignTable := .ForeignTable | $.SchemaTable -}}
-		{{- $canSoftDelete := (getTable $.Tables .ForeignTable).CanSoftDelete }}
+		{{- $canSoftDelete := (getTable $.Tables .ForeignTable).CanSoftDelete $.AutoColumns.Deleted}}
 // {{$relAlias.Local}} retrieves all the {{.ForeignTable | singular}}'s {{$ftable.UpPlural}} with an executor
 {{- if not (eq $relAlias.Local $ftable.UpPlural)}} via {{$rel.ForeignColumn}} column{{- end}}.
 func (o *{{$ltable.UpSingular}}) {{$relAlias.Local}}(mods ...qm.QueryMod) {{$ftable.DownSingular}}Query {

--- a/templates/main/07_relationship_to_one_eager.go.tpl
+++ b/templates/main/07_relationship_to_one_eager.go.tpl
@@ -8,7 +8,7 @@
 		{{- $col := $ltable.Column $fkey.Column -}}
 		{{- $fcol := $ftable.Column $fkey.ForeignColumn -}}
 		{{- $usesPrimitives := usesPrimitives $.Tables $fkey.Table $fkey.Column $fkey.ForeignTable $fkey.ForeignColumn -}}
-		{{- $canSoftDelete := (getTable $.Tables $fkey.ForeignTable).CanSoftDelete }}
+		{{- $canSoftDelete := (getTable $.Tables $fkey.ForeignTable).CanSoftDelete $.AutoColumns.Deleted }}
 // Load{{$rel.Foreign}} allows an eager lookup of values, cached into the
 // loaded structs of the objects. This is for an N-1 relationship.
 func ({{$ltable.DownSingular}}L) Load{{$rel.Foreign}}({{if $.NoContext}}e boil.Executor{{else}}ctx context.Context, e boil.ContextExecutor{{end}}, singular bool, {{$arg}} interface{}, mods queries.Applicator) error {

--- a/templates/main/08_relationship_one_to_one_eager.go.tpl
+++ b/templates/main/08_relationship_one_to_one_eager.go.tpl
@@ -8,7 +8,7 @@
 		{{- $fcol := $ftable.Column $rel.ForeignColumn -}}
 		{{- $usesPrimitives := usesPrimitives $.Tables $rel.Table $rel.Column $rel.ForeignTable $rel.ForeignColumn -}}
 		{{- $arg := printf "maybe%s" $ltable.UpSingular -}}
-		{{- $canSoftDelete := (getTable $.Tables $rel.ForeignTable).CanSoftDelete }}
+		{{- $canSoftDelete := (getTable $.Tables $rel.ForeignTable).CanSoftDelete $.AutoColumns.Deleted }}
 // Load{{$relAlias.Local}} allows an eager lookup of values, cached into the
 // loaded structs of the objects. This is for a 1-1 relationship.
 func ({{$ltable.DownSingular}}L) Load{{$relAlias.Local}}({{if $.NoContext}}e boil.Executor{{else}}ctx context.Context, e boil.ContextExecutor{{end}}, singular bool, {{$arg}} interface{}, mods queries.Applicator) error {

--- a/templates/main/09_relationship_to_many_eager.go.tpl
+++ b/templates/main/09_relationship_to_many_eager.go.tpl
@@ -9,7 +9,7 @@
 		{{- $usesPrimitives := usesPrimitives $.Tables $rel.Table $rel.Column $rel.ForeignTable $rel.ForeignColumn -}}
 		{{- $arg := printf "maybe%s" $ltable.UpSingular -}}
 		{{- $schemaForeignTable := $rel.ForeignTable | $.SchemaTable -}}
-		{{- $canSoftDelete := (getTable $.Tables $rel.ForeignTable).CanSoftDelete }}
+		{{- $canSoftDelete := (getTable $.Tables $rel.ForeignTable).CanSoftDelete $.AutoColumns.Deleted }}
 // Load{{$relAlias.Local}} allows an eager lookup of values, cached into the
 // loaded structs of the objects. This is for a 1-M or N-M relationship.
 func ({{$ltable.DownSingular}}L) Load{{$relAlias.Local}}({{if $.NoContext}}e boil.Executor{{else}}ctx context.Context, e boil.ContextExecutor{{end}}, singular bool, {{$arg}} interface{}, mods queries.Applicator) error {

--- a/templates/main/13_all.go.tpl
+++ b/templates/main/13_all.go.tpl
@@ -1,6 +1,6 @@
 {{- $alias := .Aliases.Table .Table.Name}}
 {{- $schemaTable := .Table.Name | .SchemaTable}}
-{{- $canSoftDelete := .Table.CanSoftDelete }}
+{{- $canSoftDelete := .Table.CanSoftDelete $.AutoColumns.Deleted }}
 // {{$alias.UpPlural}} retrieves all the records using an executor.
 func {{$alias.UpPlural}}(mods ...qm.QueryMod) {{$alias.DownSingular}}Query {
     {{if and .AddSoftDeletes $canSoftDelete -}}

--- a/templates/main/14_find.go.tpl
+++ b/templates/main/14_find.go.tpl
@@ -2,7 +2,7 @@
 {{- $colDefs := sqlColDefinitions .Table.Columns .Table.PKey.Columns -}}
 {{- $pkNames := $colDefs.Names | stringMap (aliasCols $alias) | stringMap .StringFuncs.camelCase | stringMap .StringFuncs.replaceReserved -}}
 {{- $pkArgs := joinSlices " " $pkNames $colDefs.Types | join ", " -}}
-{{- $canSoftDelete := .Table.CanSoftDelete }}
+{{- $canSoftDelete := .Table.CanSoftDelete $.AutoColumns.Deleted }}
 {{if .AddGlobal -}}
 // Find{{$alias.UpSingular}}G retrieves a single record by ID.
 func Find{{$alias.UpSingular}}G({{if not .NoContext}}ctx context.Context, {{end -}} {{$pkArgs}}, selectCols ...string) (*{{$alias.UpSingular}}, error) {

--- a/templates/main/18_delete.go.tpl
+++ b/templates/main/18_delete.go.tpl
@@ -1,6 +1,6 @@
 {{- $alias := .Aliases.Table .Table.Name -}}
 {{- $schemaTable := .Table.Name | .SchemaTable -}}
-{{- $canSoftDelete := .Table.CanSoftDelete -}}
+{{- $canSoftDelete := .Table.CanSoftDelete $.AutoColumns.Deleted -}}
 {{- $soft := and .AddSoftDeletes $canSoftDelete }}
 {{if .AddGlobal -}}
 // DeleteG deletes a single {{$alias.UpSingular}} record.
@@ -69,7 +69,7 @@ func (o *{{$alias.UpSingular}}) Delete({{if .NoContext}}exec boil.Executor{{else
 	} else {
 		currTime := time.Now().In(boil.GetLocation())
 		o.DeletedAt = null.TimeFrom(currTime)
-		wl := []string{(or $.AutoColumns.Deleted "deleted_at")}
+		wl := []string{"{{or $.AutoColumns.Deleted "deleted_at"}}"}
 		sql = fmt.Sprintf("UPDATE {{$schemaTable}} SET %s WHERE {{if .Dialect.UseIndexPlaceholders}}{{whereClause .LQ .RQ 2 .Table.PKey.Columns}}{{else}}{{whereClause .LQ .RQ 0 .Table.PKey.Columns}}{{end}}",
 			strmangle.SetParamNames("{{.LQ}}", "{{.RQ}}", {{if .Dialect.UseIndexPlaceholders}}1{{else}}0{{end}}, wl),
 		)
@@ -164,7 +164,7 @@ func (q {{$alias.DownSingular}}Query) DeleteAll({{if .NoContext}}exec boil.Execu
 		queries.SetDelete(q.Query)
 	} else {
 		currTime := time.Now().In(boil.GetLocation())
-		queries.SetUpdate(q.Query, M{(or $.AutoColumns.Deleted "deleted_at"): currTime})
+		queries.SetUpdate(q.Query, M{"{{or $.AutoColumns.Deleted "deleted_at"}}": currTime})
 	}
 	{{else -}}
 	queries.SetDelete(q.Query)
@@ -271,7 +271,7 @@ func (o {{$alias.UpSingular}}Slice) DeleteAll({{if .NoContext}}exec boil.Executo
 			args = append(args, pkeyArgs...)
 			obj.DeletedAt = null.TimeFrom(currTime)
 		}
-		wl := []string{(or $.AutoColumns.Deleted "deleted_at")}
+		wl := []string{"{{or $.AutoColumns.Deleted "deleted_at"}}"}
 		sql = fmt.Sprintf("UPDATE {{$schemaTable}} SET %s WHERE " +
 			strmangle.WhereClauseRepeated(string(dialect.LQ), string(dialect.RQ), {{if .Dialect.UseIndexPlaceholders}}2{{else}}0{{end}}, {{$alias.DownSingular}}PrimaryKeyColumns, len(o)),
 			strmangle.SetParamNames("{{.LQ}}", "{{.RQ}}", {{if .Dialect.UseIndexPlaceholders}}1{{else}}0{{end}}, wl),

--- a/templates/main/19_reload.go.tpl
+++ b/templates/main/19_reload.go.tpl
@@ -1,6 +1,6 @@
 {{- $alias := .Aliases.Table .Table.Name -}}
 {{- $schemaTable := .Table.Name | .SchemaTable -}}
-{{- $canSoftDelete := .Table.CanSoftDelete }}
+{{- $canSoftDelete := .Table.CanSoftDelete $.AutoColumns.Deleted }}
 {{if .AddGlobal -}}
 // ReloadG refetches the object from the database using the primary keys.
 func (o *{{$alias.UpSingular}}) ReloadG({{if not .NoContext}}ctx context.Context{{end}}) error {

--- a/templates/main/20_exists.go.tpl
+++ b/templates/main/20_exists.go.tpl
@@ -3,7 +3,7 @@
 {{- $pkNames := $colDefs.Names | stringMap (aliasCols $alias) | stringMap .StringFuncs.camelCase | stringMap .StringFuncs.replaceReserved -}}
 {{- $pkArgs := joinSlices " " $pkNames $colDefs.Types | join ", " -}}
 {{- $schemaTable := .Table.Name | .SchemaTable -}}
-{{- $canSoftDelete := .Table.CanSoftDelete }}
+{{- $canSoftDelete := .Table.CanSoftDelete $.AutoColumns.Deleted }}
 {{if .AddGlobal -}}
 // {{$alias.UpSingular}}ExistsG checks if the {{$alias.UpSingular}} row exists.
 func {{$alias.UpSingular}}ExistsG({{if not .NoContext}}ctx context.Context, {{end -}} {{$pkArgs}}) (bool, error) {

--- a/templates/test/relationship_one_to_one_setops.go.tpl
+++ b/templates/test/relationship_one_to_one_setops.go.tpl
@@ -8,7 +8,7 @@
 		{{- $colField := $ltable.Column $rel.Column -}}
 		{{- $fcolField := $ftable.Column $rel.ForeignColumn -}}
 		{{- $foreignPKeyCols := (getTable $.Tables .ForeignTable).PKey.Columns }}
-		{{- $canSoftDelete := (getTable $.Tables .ForeignTable).CanSoftDelete }}
+		{{- $canSoftDelete := (getTable $.Tables .ForeignTable).CanSoftDelete $.AutoColumns.Deleted }}
 func test{{$ltable.UpSingular}}OneToOneSetOp{{$ftable.UpSingular}}Using{{$relAlias.Local}}(t *testing.T) {
 	var err error
 

--- a/templates/test/singleton/boil_suites_test.go.tpl
+++ b/templates/test/singleton/boil_suites_test.go.tpl
@@ -19,7 +19,7 @@ func TestSoftDelete(t *testing.T) {
   {{- range .Tables}}
   {{- if .IsJoinTable -}}
   {{- else -}}
-  	{{- if .CanSoftDelete -}}
+  	{{- if .CanSoftDelete $.AutoColumns.Deleted -}}
       {{- $alias := $.Aliases.Table .Name -}}
       t.Run("{{$alias.UpPlural}}", test{{$alias.UpPlural}}SoftDelete)
   	{{end -}}
@@ -31,7 +31,7 @@ func TestQuerySoftDeleteAll(t *testing.T) {
   {{- range .Tables}}
   {{- if .IsJoinTable -}}
   {{- else -}}
-  	{{- if .CanSoftDelete -}}
+  	{{- if .CanSoftDelete $.AutoColumns.Deleted -}}
       {{- $alias := $.Aliases.Table .Name -}}
       t.Run("{{$alias.UpPlural}}", test{{$alias.UpPlural}}QuerySoftDeleteAll)
   	{{end -}}
@@ -43,7 +43,7 @@ func TestSliceSoftDeleteAll(t *testing.T) {
   {{- range .Tables}}
   {{- if .IsJoinTable -}}
   {{- else -}}
-  	{{- if .CanSoftDelete -}}
+  	{{- if .CanSoftDelete $.AutoColumns.Deleted -}}
       {{- $alias := $.Aliases.Table .Name -}}
       t.Run("{{$alias.UpPlural}}", test{{$alias.UpPlural}}SliceSoftDeleteAll)
   	{{end -}}


### PR DESCRIPTION
#962 seems to have broken soft deletes.

1. The generation fails because of a syntax error
2. Even if it succeeded, soft deletes would be disabled if the user changed the `deleted_at` column name since `table.CanSoftDelete()` did not take the customization into account.

I've fixed these in this PR, tests are all passing and from my own personal testing, it seems to be working as expected.