### PR TITLE
Collect cascade option on FKs

### DIFF
--- a/drivers/keys.go
+++ b/drivers/keys.go
@@ -2,6 +2,16 @@ package drivers
 
 import "fmt"
 
+type ForeignKeyAction string
+
+const (
+	ForeignKeyNoAction   ForeignKeyAction = "a"
+	ForeignKeyRestrict                    = "r"
+	ForeignKeyCascade                     = "c"
+	ForeignKeySetNull                     = "n"
+	ForeignKeySetDefault                  = "d"
+)
+
 // PrimaryKey represents a primary key constraint in a database
 type PrimaryKey struct {
 	Name    string   `json:"name"`
@@ -10,11 +20,13 @@ type PrimaryKey struct {
 
 // ForeignKey represents a foreign key constraint in a database
 type ForeignKey struct {
-	Table    string `json:"table"`
-	Name     string `json:"name"`
-	Column   string `json:"column"`
-	Nullable bool   `json:"nullable"`
-	Unique   bool   `json:"unique"`
+	Table        string           `json:"table"`
+	Name         string           `json:"name"`
+	Column       string           `json:"column"`
+	Nullable     bool             `json:"nullable"`
+	Unique       bool             `json:"unique"`
+	DeleteAction ForeignKeyAction `json:"delete_action"`
+	UpdateAction ForeignKeyAction `json:"update_action"`
 
 	ForeignTable          string `json:"foreign_table"`
 	ForeignColumn         string `json:"foreign_column"`

--- a/drivers/relationships.go
+++ b/drivers/relationships.go
@@ -7,10 +7,12 @@ package drivers
 type ToOneRelationship struct {
 	Name string `json:"name"`
 
-	Table    string `json:"table"`
-	Column   string `json:"column"`
-	Nullable bool   `json:"nullable"`
-	Unique   bool   `json:"unique"`
+	Table        string           `json:"table"`
+	Column       string           `json:"column"`
+	Nullable     bool             `json:"nullable"`
+	Unique       bool             `json:"unique"`
+	DeleteAction ForeignKeyAction `json:"delete_action"`
+	UpdateAction ForeignKeyAction `json:"update_action"`
 
 	ForeignTable          string `json:"foreign_table"`
 	ForeignColumn         string `json:"foreign_column"`
@@ -24,10 +26,12 @@ type ToOneRelationship struct {
 type ToManyRelationship struct {
 	Name string `json:"name"`
 
-	Table    string `json:"table"`
-	Column   string `json:"column"`
-	Nullable bool   `json:"nullable"`
-	Unique   bool   `json:"unique"`
+	Table        string           `json:"table"`
+	Column       string           `json:"column"`
+	Nullable     bool             `json:"nullable"`
+	Unique       bool             `json:"unique"`
+	DeleteAction ForeignKeyAction `json:"delete_action"`
+	UpdateAction ForeignKeyAction `json:"update_action"`
 
 	ForeignTable          string `json:"foreign_table"`
 	ForeignColumn         string `json:"foreign_column"`
@@ -93,11 +97,13 @@ func toManyRelationships(table Table, tables []Table) []ToManyRelationship {
 
 func buildToOneRelationship(localTable Table, foreignKey ForeignKey, foreignTable Table, tables []Table) ToOneRelationship {
 	return ToOneRelationship{
-		Name:     foreignKey.Name,
-		Table:    localTable.Name,
-		Column:   foreignKey.ForeignColumn,
-		Nullable: foreignKey.ForeignColumnNullable,
-		Unique:   foreignKey.ForeignColumnUnique,
+		Name:         foreignKey.Name,
+		Table:        localTable.Name,
+		Column:       foreignKey.ForeignColumn,
+		Nullable:     foreignKey.ForeignColumnNullable,
+		Unique:       foreignKey.ForeignColumnUnique,
+		DeleteAction: foreignKey.DeleteAction,
+		UpdateAction: foreignKey.UpdateAction,
 
 		ForeignTable:          foreignTable.Name,
 		ForeignColumn:         foreignKey.Column,
@@ -114,6 +120,8 @@ func buildToManyRelationship(localTable Table, foreignKey ForeignKey, foreignTab
 			Column:                foreignKey.ForeignColumn,
 			Nullable:              foreignKey.ForeignColumnNullable,
 			Unique:                foreignKey.ForeignColumnUnique,
+			DeleteAction:          foreignKey.DeleteAction,
+			UpdateAction:          foreignKey.UpdateAction,
 			ForeignTable:          foreignTable.Name,
 			ForeignColumn:         foreignKey.Column,
 			ForeignColumnNullable: foreignKey.Nullable,
@@ -123,10 +131,12 @@ func buildToManyRelationship(localTable Table, foreignKey ForeignKey, foreignTab
 	}
 
 	relationship := ToManyRelationship{
-		Table:    localTable.Name,
-		Column:   foreignKey.ForeignColumn,
-		Nullable: foreignKey.ForeignColumnNullable,
-		Unique:   foreignKey.ForeignColumnUnique,
+		Table:        localTable.Name,
+		Column:       foreignKey.ForeignColumn,
+		Nullable:     foreignKey.ForeignColumnNullable,
+		Unique:       foreignKey.ForeignColumnUnique,
+		DeleteAction: foreignKey.DeleteAction,
+		UpdateAction: foreignKey.UpdateAction,
 
 		ToJoinTable: true,
 		JoinTable:   foreignTable.Name,

--- a/drivers/sqlboiler-psql/driver/psql.go
+++ b/drivers/sqlboiler-psql/driver/psql.go
@@ -231,12 +231,12 @@ func (p *PostgresDriver) Columns(schema, tableName string, whitelist, blacklist 
 		c.is_nullable = 'YES' as is_nullable,
 		(case
 			when (select
-		    case
-			    when column_name = 'is_identity' then (select c.is_identity = 'YES' as is_identity)
-		    else
-			    false
-		    end as is_identity from information_schema.columns
-		    WHERE table_schema='information_schema' and table_name='columns' and column_name='is_identity') IS NULL then 'NO' else is_identity end) = 'YES' as is_identity,
+				case
+					when column_name = 'is_identity' then (select c.is_identity = 'YES' as is_identity)
+				else
+					false
+				end as is_identity from information_schema.columns
+				WHERE table_schema='information_schema' and table_name='columns' and column_name='is_identity') IS NULL then 'NO' else is_identity end) = 'YES' as is_identity,
 		(select exists(
 			select 1
 			from information_schema.table_constraints tc
@@ -409,6 +409,8 @@ func (p *PostgresDriver) ForeignKeyInfo(schema, tableName string) ([]drivers.For
 	query := fmt.Sprintf(`
 	select
 		pgcon.conname,
+		pgcon.confdeltype delete_action,
+		pgcon.confupdtype update_action,
 		pgc.relname as source_table,
 		pgasrc.attname as source_column,
 		dstlookupname.relname as dest_table,
@@ -435,7 +437,7 @@ func (p *PostgresDriver) ForeignKeyInfo(schema, tableName string) ([]drivers.For
 		var sourceTable string
 
 		fkey.Table = tableName
-		err = rows.Scan(&fkey.Name, &sourceTable, &fkey.Column, &fkey.ForeignTable, &fkey.ForeignColumn)
+		err = rows.Scan(&fkey.Name, &fkey.DeleteAction, &fkey.UpdateAction, &sourceTable, &fkey.Column, &fkey.ForeignTable, &fkey.ForeignColumn)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Initially Postgres-only, this collects any actions configured on foreign keys during database introspection so that data can be used in the template generation later.

I'm running SQLBoiler with some pretty custom templates, this information is useful for being able to know in Go what will happen in the database when keys are updated or deleted. Unsure if you have a policy of only accepting features that are engine-agnostic but thought I'd throw this up for feedback to potentially save continuing to maintain a fork