### PR TITLE
Update volatiletech/null dependency to v9.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ into your `go.mod` file at the correct version.
 # Do not forget the trailing /v4 and /v8 in the following commands
 go get github.com/volatiletech/sqlboiler/v4
 # Assuming you're going to use the null package for its additional null types
-go get github.com/volatiletech/null/v8
+go get github.com/volatiletech/null/v9
 ```
 
 #### Configuration

--- a/drivers/mocks/mock.go
+++ b/drivers/mocks/mock.go
@@ -23,16 +23,16 @@ func (m *MockDriver) Imports() (importers.Collection, error) {
 	return importers.Collection{
 		BasedOnType: importers.Map{
 			"null.Int": {
-				ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+				ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 			},
 			"null.String": {
-				ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+				ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 			},
 			"null.Time": {
-				ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+				ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 			},
 			"null.Bytes": {
-				ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+				ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 			},
 
 			"time.Time": {

--- a/drivers/sqlboiler-mssql/driver/mssql.go
+++ b/drivers/sqlboiler-mssql/driver/mssql.go
@@ -509,52 +509,52 @@ func (MSSQLDriver) Imports() (col importers.Collection, err error) {
 
 	col.BasedOnType = importers.Map{
 		"null.Float32": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Float64": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Int": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Int8": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Int16": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Int32": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Int64": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Uint": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Uint8": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Uint16": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Uint32": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Uint64": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.String": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Bool": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Time": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Bytes": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"time.Time": {
 			Standard: importers.List{`"time"`},

--- a/drivers/sqlboiler-mysql/driver/mysql.go
+++ b/drivers/sqlboiler-mysql/driver/mysql.go
@@ -531,55 +531,55 @@ func (MySQLDriver) Imports() (col importers.Collection, err error) {
 
 	col.BasedOnType = importers.Map{
 		"null.Float32": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Float64": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Int": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Int8": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Int16": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Int32": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Int64": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Uint": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Uint8": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Uint16": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Uint32": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Uint64": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.String": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Bool": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Time": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Bytes": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.JSON": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 
 		"time.Time": {

--- a/drivers/sqlboiler-psql/driver/psql.go
+++ b/drivers/sqlboiler-psql/driver/psql.go
@@ -678,55 +678,55 @@ func (p PostgresDriver) Imports() (importers.Collection, error) {
 	}
 	col.BasedOnType = importers.Map{
 		"null.Float32": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Float64": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Int": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Int8": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Int16": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Int32": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Int64": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Uint": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Uint8": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Uint16": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Uint32": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Uint64": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.String": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Bool": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Time": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.JSON": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"null.Bytes": {
-			ThirdParty: importers.List{`"github.com/volatiletech/null/v8"`},
+			ThirdParty: importers.List{`"github.com/volatiletech/null/v9"`},
 		},
 		"time.Time": {
 			Standard: importers.List{`"time"`},

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/spf13/cast v1.4.1
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.9.0
-	github.com/volatiletech/null/v8 v8.1.2
+	github.com/volatiletech/null/v9 v9.0.0
 	github.com/volatiletech/randomize v0.0.1
 	github.com/volatiletech/strmangle v0.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -304,6 +304,8 @@ github.com/volatiletech/inflect v0.0.1 h1:2a6FcMQyhmPZcLa+uet3VJ8gLn/9svWhJxJYwv
 github.com/volatiletech/inflect v0.0.1/go.mod h1:IBti31tG6phkHitLlr5j7shC5SOo//x0AjDzaJU1PLA=
 github.com/volatiletech/null/v8 v8.1.2 h1:kiTiX1PpwvuugKwfvUNX/SU/5A2KGZMXfGD0DUHdKEI=
 github.com/volatiletech/null/v8 v8.1.2/go.mod h1:98DbwNoKEpRrYtGjWFctievIfm4n4MxG0A6EBUcoS5g=
+github.com/volatiletech/null/v9 v9.0.0 h1:JCdlHEiSRVxOi7/MABiEfdsqmuj9oTV20Ao7VvZ0JkE=
+github.com/volatiletech/null/v9 v9.0.0/go.mod h1:zRFghPVahaiIMRXiUJrc6gsoG83Cm3ZoAfSTw7VHGQc=
 github.com/volatiletech/randomize v0.0.1 h1:eE5yajattWqTB2/eN8df4dw+8jwAzBtbdo5sbWC4nMk=
 github.com/volatiletech/randomize v0.0.1/go.mod h1:GN3U0QYqfZ9FOJ67bzax1cqZ5q2xuj2mXrXBjWaRTlY=
 github.com/volatiletech/strmangle v0.0.1 h1:UKQoHmY6be/R3tSvD2nQYrH41k43OJkidwEiC74KIzk=

--- a/importers/imports_test.go
+++ b/importers/imports_test.go
@@ -186,7 +186,7 @@ func TestAddTypeImports(t *testing.T) {
 			`"time"`,
 		},
 		ThirdParty: List{
-			`"github.com/volatiletech/null/v8"`,
+			`"github.com/volatiletech/null/v9"`,
 			`"github.com/volatiletech/sqlboiler/v4/boil"`,
 		},
 	}
@@ -200,7 +200,7 @@ func TestAddTypeImports(t *testing.T) {
 	imps := NewDefaultImports()
 
 	imps.BasedOnType = Map{
-		"null.Time": Set{ThirdParty: List{`"github.com/volatiletech/null/v8"`}},
+		"null.Time": Set{ThirdParty: List{`"github.com/volatiletech/null/v9"`}},
 		"time.Time": Set{Standard: List{`"time"`}},
 	}
 
@@ -217,7 +217,7 @@ func TestAddTypeImports(t *testing.T) {
 			`"time"`,
 		},
 		ThirdParty: List{
-			`"github.com/volatiletech/null/v8"`,
+			`"github.com/volatiletech/null/v9"`,
 			`"github.com/volatiletech/sqlboiler/v4/boil"`,
 		},
 	}
@@ -234,7 +234,7 @@ func TestMergeSet(t *testing.T) {
 
 	a := Set{
 		Standard:   List{"fmt"},
-		ThirdParty: List{"github.com/volatiletech/sqlboiler/v4", "github.com/volatiletech/null/v8"},
+		ThirdParty: List{"github.com/volatiletech/sqlboiler/v4", "github.com/volatiletech/null/v9"},
 	}
 	b := Set{
 		Standard:   List{"os"},
@@ -246,8 +246,8 @@ func TestMergeSet(t *testing.T) {
 	if c.Standard[0] != "fmt" && c.Standard[1] != "os" {
 		t.Errorf("Wanted: fmt, os got: %#v", c.Standard)
 	}
-	if c.ThirdParty[0] != "github.com/volatiletech/null/v8" && c.ThirdParty[1] != "github.com/volatiletech/sqlboiler/v4" {
-		t.Errorf("Wanted: github.com/volatiletech/sqlboiler, github.com/volatiletech/null/v8 got: %#v", c.ThirdParty)
+	if c.ThirdParty[0] != "github.com/volatiletech/null/v9" && c.ThirdParty[1] != "github.com/volatiletech/sqlboiler/v4" {
+		t.Errorf("Wanted: github.com/volatiletech/sqlboiler, github.com/volatiletech/null/v9 got: %#v", c.ThirdParty)
 	}
 }
 

--- a/queries/helpers_test.go
+++ b/queries/helpers_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/volatiletech/null/v8"
+	"github.com/volatiletech/null/v9"
 )
 
 type testObj struct {

--- a/queries/reflect_test.go
+++ b/queries/reflect_test.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/volatiletech/null/v9"
 	"github.com/volatiletech/sqlboiler/v4/drivers"
-	"github.com/volatiletech/null/v8"
 
 	"github.com/DATA-DOG/go-sqlmock"
 )

--- a/types/hstore.go
+++ b/types/hstore.go
@@ -24,7 +24,7 @@ import (
 	"database/sql/driver"
 	"strings"
 
-	"github.com/volatiletech/null/v8"
+	"github.com/volatiletech/null/v9"
 	"github.com/volatiletech/randomize"
 )
 


### PR DESCRIPTION
This PR updates the dependency on volatiletech/null to the newly released [v9.0.0](https://github.com/volatiletech/null/commit/ad763b656f3239c1d8127db501bd4b148de59712).

This might technically be a breaking change that requires waiting until the next major version, as anybody serializing a sqlboiler-generated type to JSON will see a different serialization than before if their type contains a `null.Bytes` field.