### PR TITLE
Support * wildcard as table name in black/white listing of columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,10 +359,11 @@ Example of whitelist/blacklist:
 
 ```toml
 [psql]
-# Removes migrations table, and the name column from the addresses table
-# from being generated. Foreign keys that reference tables or columns that
-# are no longer generated because of whitelists or blacklists may cause problems.
-blacklist = ["migrations", "addresses.name"]
+# Removes migrations table, the name column from the addresses table, and
+# secret_col of any table from being generated. Foreign keys that reference tables
+# or columns that are no longer generated because of whitelists or blacklists may
+# cause problems.
+blacklist = ["migrations", "addresses.name", "*.secret_col"]
 ```
 
 ##### Generic config options

--- a/drivers/config.go
+++ b/drivers/config.go
@@ -204,7 +204,7 @@ func ColumnsFromList(list []string, tablename string) []string {
 			continue
 		}
 
-		if splits[0] == tablename {
+		if splits[0] == tablename || splits[0] == "*" {
 			columns = append(columns, splits[1])
 		}
 	}

--- a/drivers/config_test.go
+++ b/drivers/config_test.go
@@ -270,4 +270,7 @@ func TestColumnsFromList(t *testing.T) {
 	if got := ColumnsFromList([]string{"a.b", "b", "c.d", "c.a"}, "b"); len(got) != 0 {
 		t.Error("list was wrong:", got)
 	}
+	if got := ColumnsFromList([]string{"*.b", "b", "c.d"}, "c"); !reflect.DeepEqual(got, []string{"b", "d"}) {
+		t.Error("list was wrong:", got)
+	}
 }


### PR DESCRIPTION
This PR adds support for `*` as a wildcard for the table name in the white/black listing of columns.

This allows one to use `blacklist = ["*.tenant_id"]` to prevent all `tenant_id` columns (from any table) related code to be generated, rather than explicitly listing all tables having this column.

---

Unrelated note: Thank you for this amazing lib!