### PR TITLE
Fix panic with zero value of types.NullDecimal

### DIFF
--- a/types/decimal.go
+++ b/types/decimal.go
@@ -167,9 +167,13 @@ func randomDecimal(nextInt func() int64, fieldType string, shouldBeNull bool) *d
 	return random
 }
 
-func decimalValue(d *decimal.Big, canNil bool) (driver.Value, error) {
-	if !canNil && d == nil {
-		return nil, nil
+func decimalValue(d *decimal.Big, canNull bool) (driver.Value, error) {
+	if d == nil {
+		if canNull {
+			return nil, nil
+		}
+
+		return "0", nil
 	}
 
 	if d.IsNaN(0) {

--- a/types/decimal_test.go
+++ b/types/decimal_test.go
@@ -105,6 +105,10 @@ func TestNullDecimal_Value(t *testing.T) {
 		}
 	}
 
+	zero := NullDecimal{}
+	if _, err := zero.Value(); err != nil {
+		t.Error("zero value should not error")
+	}
 	infinity := NullDecimal{Big: new(decimal.Big).SetInf(true)}
 	if _, err := infinity.Value(); err == nil {
 		t.Error("infinity should not be passed into the database")


### PR DESCRIPTION
Also make `types.Decimal` return `0` when nil to prevent violating a `NOT NULL` constraint.