### PR TITLE
Simultaneous generation of the same nullable and non-nullable enum type (fix)

### DIFF
--- a/templates/main/singleton/boil_types.go.tpl
+++ b/templates/main/singleton/boil_types.go.tpl
@@ -71,8 +71,8 @@ It only titlecases the EnumValue portion if it's snake-cased.
 		{{- if not (and
 			$isNamed
 			(and
-				(onceHas $once $name)
-				(onceHas $onceNull $name)
+				($once.Has $name)
+				($onceNull.Has $name)
 			)
 		) -}}
 			{{- if and (gt (len $vals) 0) (isEnumNormal $vals)}}
@@ -83,8 +83,8 @@ It only titlecases the EnumValue portion if it's snake-cased.
 				{{- end -}}
 				{{/* First iteration for enum type $name (nullable or not) */}}
 				{{- $enumFirstIter := and
-					(not (onceHas $once $name))
-					(not (onceHas $onceNull $name))
+					(not ($once.Has $name))
+					(not ($onceNull.Has $name))
 				-}}
 
 				{{- if $enumFirstIter -}}
@@ -142,7 +142,7 @@ It only titlecases the EnumValue portion if it's snake-cased.
 
 					{{ if and
 						$col.Nullable
-						(not (onceHas $onceNull $name))
+						(not ($onceNull.Has $name))
 					}}
 						{{$enumType := ""}}
 						{{- if $isNamed -}}
@@ -267,9 +267,9 @@ It only titlecases the EnumValue portion if it's snake-cased.
 			 inside the $table.Columns loop. */}}
 			{{- if $isNamed -}}
 				{{- if $col.Nullable -}}
-					{{$_ := oncePut $onceNull $name}}
+					{{$_ := $onceNull.Put $name}}
 				{{- else -}}
-					{{$_ := oncePut $once $name}}
+					{{$_ := $once.Put $name}}
 				{{- end -}}
 			{{- end -}}
 		{{- end -}}


### PR DESCRIPTION
**Problem:**
When using PostgreSQL/CockroachDB if the same enum type is used for both nullable and non-nullable columns (across all tables), only the Go type of the first column is being generated at the moment (because of the `onceHas` check in the template).
https://github.com/volatiletech/sqlboiler/blob/7e7fd0cb90d18291c74879109350d3448c97e87c/templates/main/singleton/boil_types.go.tpl#L70
Also if the non-nullable enum type was generated first, the detection of nullable enum column will cause the rendering of `NullableEnumImports`, thus corrupting the generated `boil_types.go` file, because these imports aren't going to be used (nullable Go type that uses those imports not generated because of the `onceHas` check).

**Solution**:
In addition to the `$once` map in `boil_types.go.tpl` add `$onceNull` map to save the names of generated nullable enum types and check them separately.