### PR TITLE
Generate IN/NIN whereHelpers for nullable types

### DIFF
--- a/boilingcore/templates.go
+++ b/boilingcore/templates.go
@@ -312,11 +312,11 @@ var templateFunctions = template.FuncMap{
 	"whereClause": strmangle.WhereClause,
 
 	// Alias and text helping
-	"aliasCols":       func(ta TableAlias) func(string) string { return ta.Column },
-	"usesPrimitives":  usesPrimitives,
-	"isPrimitive":     isPrimitive,
-	"isNullPrimitive": isNullPrimitive,
-	"toPrimitive":     toPrimitive,
+	"aliasCols":              func(ta TableAlias) func(string) string { return ta.Column },
+	"usesPrimitives":         usesPrimitives,
+	"isPrimitive":            isPrimitive,
+	"isNullPrimitive":        isNullPrimitive,
+	"convertNullToPrimitive": convertNullToPrimitive,
 	"splitLines": func(a string) []string {
 		if a == "" {
 			return nil

--- a/boilingcore/templates.go
+++ b/boilingcore/templates.go
@@ -312,9 +312,11 @@ var templateFunctions = template.FuncMap{
 	"whereClause": strmangle.WhereClause,
 
 	// Alias and text helping
-	"aliasCols":      func(ta TableAlias) func(string) string { return ta.Column },
-	"usesPrimitives": usesPrimitives,
-	"isPrimitive":    isPrimitive,
+	"aliasCols":       func(ta TableAlias) func(string) string { return ta.Column },
+	"usesPrimitives":  usesPrimitives,
+	"isPrimitive":     isPrimitive,
+	"isNullPrimitive": isNullPrimitive,
+	"toPrimitive":     toPrimitive,
 	"splitLines": func(a string) []string {
 		if a == "" {
 			return nil

--- a/boilingcore/text_helpers.go
+++ b/boilingcore/text_helpers.go
@@ -151,3 +151,29 @@ func isPrimitive(typ string) bool {
 
 	return false
 }
+
+func isNullPrimitive(typ string) bool {
+	switch typ {
+	// Numeric
+	case "null.Int", "null.Int8", "null.Int16", "null.Int32", "null.Int64":
+		return true
+	case "null.Uint", "null.Uint8", "null.Uint16", "null.Uint32", "null.Uint64":
+		return true
+	case "null.Float32", "null.Float64":
+		return true
+	case "null.Byte", "null.String":
+		return true
+	}
+
+	return false
+}
+
+// toPrimitive takes a type name and returns the underlying primitive type name X if it is a `null.X`,
+// otherwise it returns the input value unchanged
+func toPrimitive(typ string) string {
+	if isNullPrimitive(typ) {
+		return strings.ToLower(strings.Split(typ, ".")[1])
+	}
+	return typ
+}
+

--- a/boilingcore/text_helpers.go
+++ b/boilingcore/text_helpers.go
@@ -168,12 +168,11 @@ func isNullPrimitive(typ string) bool {
 	return false
 }
 
-// toPrimitive takes a type name and returns the underlying primitive type name X if it is a `null.X`,
+// convertNullToPrimitive takes a type name and returns the underlying primitive type name X if it is a `null.X`,
 // otherwise it returns the input value unchanged
-func toPrimitive(typ string) string {
+func convertNullToPrimitive(typ string) string {
 	if isNullPrimitive(typ) {
 		return strings.ToLower(strings.Split(typ, ".")[1])
 	}
 	return typ
 }
-

--- a/templates/main/00_struct.go.tpl
+++ b/templates/main/00_struct.go.tpl
@@ -64,14 +64,14 @@ func (w {{$name}}) LTE(x {{.Type}}) qm.QueryMod { return qmhelper.Where(w.field,
 func (w {{$name}}) GT(x {{.Type}}) qm.QueryMod { return qmhelper.Where(w.field, qmhelper.GT, x) }
 func (w {{$name}}) GTE(x {{.Type}}) qm.QueryMod { return qmhelper.Where(w.field, qmhelper.GTE, x) }
 		{{if or (isPrimitive .Type) (isNullPrimitive .Type) (isEnumDBType .DBType) -}}
-func (w {{$name}}) IN(slice []{{toPrimitive .Type}}) qm.QueryMod {
+func (w {{$name}}) IN(slice []{{convertNullToPrimitive .Type}}) qm.QueryMod {
 	values := make([]interface{}, 0, len(slice))
 	for _, value := range slice {
 		values = append(values, value)
 	}
 	return qm.WhereIn(fmt.Sprintf("%s IN ?", w.field), values...)
 }
-func (w {{$name}}) NIN(slice []{{toPrimitive .Type}}) qm.QueryMod {
+func (w {{$name}}) NIN(slice []{{convertNullToPrimitive .Type}}) qm.QueryMod {
 	values := make([]interface{}, 0, len(slice))
 	for _, value := range slice {
 	  values = append(values, value)

--- a/templates/main/00_struct.go.tpl
+++ b/templates/main/00_struct.go.tpl
@@ -63,15 +63,15 @@ func (w {{$name}}) LT(x {{.Type}}) qm.QueryMod { return qmhelper.Where(w.field, 
 func (w {{$name}}) LTE(x {{.Type}}) qm.QueryMod { return qmhelper.Where(w.field, qmhelper.LTE, x) }
 func (w {{$name}}) GT(x {{.Type}}) qm.QueryMod { return qmhelper.Where(w.field, qmhelper.GT, x) }
 func (w {{$name}}) GTE(x {{.Type}}) qm.QueryMod { return qmhelper.Where(w.field, qmhelper.GTE, x) }
-		{{if or (isPrimitive .Type) (isEnumDBType .DBType) -}}
-func (w {{$name}}) IN(slice []{{.Type}}) qm.QueryMod {
+		{{if or (isPrimitive .Type) (isNullPrimitive .Type) (isEnumDBType .DBType) -}}
+func (w {{$name}}) IN(slice []{{toPrimitive .Type}}) qm.QueryMod {
 	values := make([]interface{}, 0, len(slice))
 	for _, value := range slice {
 		values = append(values, value)
 	}
 	return qm.WhereIn(fmt.Sprintf("%s IN ?", w.field), values...)
 }
-func (w {{$name}}) NIN(slice []{{.Type}}) qm.QueryMod {
+func (w {{$name}}) NIN(slice []{{toPrimitive .Type}}) qm.QueryMod {
 	values := make([]interface{}, 0, len(slice))
 	for _, value := range slice {
 	  values = append(values, value)


### PR DESCRIPTION
Enables IN/NIN whereHelper function generation for nullable types addressing issue #851. Based on #910.

The generated helpers take the underlying primitive types, so that a `null.String` column would generate a function with signature `IN(slice []string) qm.QueryMod`

I implemented it this way (instead of accepting nullable values) for a few reasons:
 1. The code is much simpler
 2. I imagine most people aren't using `null.*` to construct these clauses currently
 3. A `NULL` in an `IN` clause is meaningless in SQL anyway, as it does not affect the result