### PR TITLE
Minor query builder improvements

### DIFF
--- a/queries/qm/query_mods.go
+++ b/queries/qm/query_mods.go
@@ -194,18 +194,30 @@ func Distinct(clause string) QueryMod {
 }
 
 type withQueryMod struct {
+	alias  string
 	clause string
 	args   []interface{}
 }
 
 // Apply implements QueryMod.Apply.
 func (qm withQueryMod) Apply(q *queries.Query) {
-	queries.AppendWith(q, qm.clause, qm.args...)
+	queries.AppendWith(q, qm.alias, qm.clause, qm.args...)
 }
 
 // With allows you to pass in a Common Table Expression clause (and args)
 func With(clause string, args ...interface{}) QueryMod {
 	return withQueryMod{
+		clause: clause,
+		args:   args,
+	}
+}
+
+// WithSubquery allows you to generate a Common Table Expression using a query
+// object to populate the CTE
+func WithSubquery(alias string, q *queries.Query) QueryMod {
+	clause, args := queries.BuildSubquery(q)
+	return withQueryMod{
+		alias:  alias,
 		clause: clause,
 		args:   args,
 	}

--- a/queries/query.go
+++ b/queries/query.go
@@ -32,7 +32,7 @@ type Query struct {
 
 	delete     bool
 	update     map[string]interface{}
-	withs      []argClause
+	withs      []with
 	selectCols []string
 	count      bool
 	from       []string
@@ -84,6 +84,12 @@ type in struct {
 }
 
 type argClause struct {
+	clause string
+	args   []interface{}
+}
+
+type with struct {
+	alias  string
 	clause string
 	args   []interface{}
 }
@@ -398,8 +404,8 @@ func AppendOrderBy(q *Query, clause string, args ...interface{}) {
 }
 
 // AppendWith on the query.
-func AppendWith(q *Query, clause string, args ...interface{}) {
-	q.withs = append(q.withs, argClause{clause: clause, args: args})
+func AppendWith(q *Query, alias, clause string, args ...interface{}) {
+	q.withs = append(q.withs, with{alias: alias, clause: clause, args: args})
 }
 
 // RemoveSoftDeleteWhere prevents the automatic soft delete where clause

--- a/queries/query_builders.go
+++ b/queries/query_builders.go
@@ -20,6 +20,18 @@ var (
 // and it's accompanying arguments. Using this method
 // allows query building without immediate execution.
 func BuildQuery(q *Query) (string, []interface{}) {
+	return buildQuery(q, true)
+}
+
+// BuildSubquery builds a query object into the query string
+// and it's accompanying arguments but doesn't append a
+// semi-colon allowing the resulting string to be embedded
+// as a subquery.
+func BuildSubquery(q *Query) (string, []interface{}) {
+	return buildQuery(q, false)
+}
+
+func buildQuery(q *Query, finalize bool) (string, []interface{}) {
 	var buf *bytes.Buffer
 	var args []interface{}
 
@@ -34,6 +46,10 @@ func BuildQuery(q *Query) (string, []interface{}) {
 		buf, args = buildUpdateQuery(q)
 	default:
 		buf, args = buildSelectQuery(q)
+	}
+
+	if finalize {
+		buf.WriteByte(';')
 	}
 
 	defer strmangle.PutBuffer(buf)
@@ -133,7 +149,6 @@ func buildSelectQuery(q *Query) (*bytes.Buffer, []interface{}) {
 
 	writeModifiers(q, buf, &args)
 
-	buf.WriteByte(';')
 	return buf, args
 }
 
@@ -154,8 +169,6 @@ func buildDeleteQuery(q *Query) (*bytes.Buffer, []interface{}) {
 	buf.WriteString(where)
 
 	writeModifiers(q, buf, &args)
-
-	buf.WriteByte(';')
 
 	return buf, args
 }
@@ -198,8 +211,6 @@ func buildUpdateQuery(q *Query) (*bytes.Buffer, []interface{}) {
 	buf.WriteString(where)
 
 	writeModifiers(q, buf, &args)
-
-	buf.WriteByte(';')
 
 	return buf, args
 }

--- a/queries/query_builders.go
+++ b/queries/query_builders.go
@@ -625,7 +625,11 @@ func writeCTEs(q *Query, buf *bytes.Buffer, args *[]interface{}) {
 	withBuf := strmangle.GetBuffer()
 	lastPos := len(q.withs) - 1
 	for i, w := range q.withs {
-		fmt.Fprintf(withBuf, " %s", w.clause)
+		if w.alias != "" {
+			fmt.Fprintf(withBuf, " %s AS (%s)", w.alias, w.clause)
+		} else {
+			fmt.Fprintf(withBuf, " %s", w.clause)
+		}
 		if i >= 0 && i < lastPos {
 			withBuf.WriteByte(',')
 		}

--- a/queries/query_builders_test.go
+++ b/queries/query_builders_test.go
@@ -119,9 +119,9 @@ func TestBuildQuery(t *testing.T) {
 		{&Query{from: []string{"cats as c", "dogs as d"}, joins: []join{{JoinOuterFull, "dogs d on d.cat_id = cats.id", nil}}}, nil},
 		{&Query{
 			from: []string{"t"},
-			withs: []argClause{
-				{"cte_0 AS (SELECT * FROM other_t0)", nil},
-				{"cte_1 AS (SELECT * FROM other_t1 WHERE thing=? AND stuff=?)", []interface{}{3, 7}},
+			withs: []with{
+				{"cte_0", "SELECT * FROM other_t0", nil},
+				{"cte_1", "SELECT * FROM other_t1 WHERE thing=? AND stuff=?", []interface{}{3, 7}},
 			},
 		}, []interface{}{3, 7},
 		},
@@ -158,6 +158,31 @@ func TestBuildQuery(t *testing.T) {
 		if !reflect.DeepEqual(args, test.args) {
 			t.Errorf("[%02d] Test failed:\nWant:\n%s\nGot:\n%s", i, spew.Sdump(test.args), spew.Sdump(args))
 		}
+	}
+}
+
+func TestBuildSubquery(t *testing.T) {
+	t.Parallel()
+
+	q1 := &Query{}
+	SetSelect(q1, []string{"foo", "bar"})
+	SetFrom(q1, "tbl")
+	q1.dialect = &drivers.Dialect{LQ: '"', RQ: '"', UseIndexPlaceholders: true}
+
+	q2 := &Query{}
+	SetSelect(q2, []string{"foo", "bar"})
+	SetFrom(q2, "tbl")
+	q2.dialect = &drivers.Dialect{LQ: '"', RQ: '"', UseIndexPlaceholders: true}
+
+	query, _ := BuildQuery(q1)
+	subquery, _ := BuildSubquery(q2)
+
+	if !strings.HasSuffix(query, ";") {
+		t.Error("BuildQuery() result is missing trailing ';'\n", query)
+	}
+
+	if strings.HasSuffix(subquery, ";") {
+		t.Error("BuildSubquery() result has trailing ';'\n", subquery)
 	}
 }
 
@@ -516,11 +541,11 @@ func TestLimitClause(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		limit *int
+		limit           *int
 		expectPredicate func(sql string) bool
 	}{
 		{nil, func(sql string) bool {
-			return !strings.Contains(sql,"LIMIT")
+			return !strings.Contains(sql, "LIMIT")
 		}},
 		{newIntPtr(0), func(sql string) bool {
 			return strings.Contains(sql, "LIMIT 0")
@@ -532,7 +557,7 @@ func TestLimitClause(t *testing.T) {
 
 	for i, test := range tests {
 		q := &Query{
-			limit: test.limit,
+			limit:   test.limit,
 			dialect: &drivers.Dialect{LQ: '"', RQ: '"', UseIndexPlaceholders: true, UseTopClause: false},
 		}
 		sql, _ := BuildQuery(q)

--- a/queries/query_test.go
+++ b/queries/query_test.go
@@ -2,7 +2,6 @@ package queries
 
 import (
 	"reflect"
-	"strings"
 	"testing"
 )
 
@@ -59,25 +58,6 @@ func TestSetLoad(t *testing.T) {
 
 	if q.load[0] != "one" || q.load[1] != "two" {
 		t.Errorf("Was not expected string, got %v", q.load)
-	}
-}
-
-func TestBuildSubquery(t *testing.T) {
-	t.Parallel()
-
-	q := &Query{}
-	SetSelect(q, []string{"foo", "bar"})
-	SetFrom(q, "tbl")
-
-	query, _ := BuildQuery(q)
-	subquery, _ := BuildSubquery(q)
-
-	if !strings.HasSuffix(query, ";") {
-		t.Error("BuildQuery() result is missing trailing ';'")
-	}
-
-	if strings.HasSuffix(subquery, ";") {
-		t.Error("BuildSubquery() result has trailing ';'")
 	}
 }
 


### PR DESCRIPTION
This PR implements the following:

- Added `queries.BuildSubquery()` which does the same thing as `BuildQuery()` except doesn't append a semicolon so query builder results can be embedded in other queries
- Added `qm.WithSubquery() which allows generating a CTE using a query object built by sqlboiler

The `WithSubquery()` modifier is interesting imo because if there's interest, there are a number of query mods that could be added to work with subqueries to allow building pretty complex, type-checked queries without horrible code.