### PR TITLE
Custom template functions for library users

### DIFF
--- a/boilingcore/boilingcore.go
+++ b/boilingcore/boilingcore.go
@@ -156,6 +156,7 @@ func (s *State) Run() error {
 		LQ:                strmangle.QuoteCharacter(s.Dialect.LQ),
 		RQ:                strmangle.QuoteCharacter(s.Dialect.RQ),
 		OutputDirDepth:    s.Config.OutputDirDepth(),
+		UserFuncs:         s.Config.TemplateUserFuncs,
 
 		DBTypes:     make(once),
 		StringFuncs: templateStringMappers,
@@ -217,7 +218,9 @@ func (s *State) Cleanup() error {
 // initTemplates loads all template folders into the state object.
 //
 // If TemplateDirs is set it uses those, else it pulls from assets.
-// Then it allows drivers to override, followed by replacements.
+// Then it allows drivers to override, followed by replacements. Any
+// user functions passed in by library users will be merged into the
+// template.FuncMap.
 //
 // Because there's the chance for windows paths to jumped in
 // all paths are converted to the native OS's slash style.

--- a/boilingcore/config.go
+++ b/boilingcore/config.go
@@ -3,6 +3,7 @@ package boilingcore
 import (
 	"path/filepath"
 	"strings"
+	"text/template"
 
 	"github.com/spf13/cast"
 
@@ -40,6 +41,8 @@ type Config struct {
 	TagIgnore         []string `toml:"tag_ignore,omitempty" json:"tag_ignore,omitempty"`
 
 	Imports importers.Collection `toml:"imports,omitempty" json:"imports,omitempty"`
+
+	TemplateUserFuncs template.FuncMap `toml:"-" json:"-"`
 
 	Aliases      Aliases       `toml:"aliases,omitempty" json:"aliases,omitempty"`
 	TypeReplaces []TypeReplace `toml:"type_replaces,omitempty" json:"type_replaces,omitempty"`

--- a/boilingcore/templates.go
+++ b/boilingcore/templates.go
@@ -72,6 +72,9 @@ type templateData struct {
 	// StringFuncs are usable in templates with stringMap
 	StringFuncs map[string]func(string) string
 
+	// UserFuncs is an optional set of user-provided template functions
+	UserFuncs template.FuncMap
+
 	// AutoColumns set the name of the columns for auto timestamps and soft deletes
 	AutoColumns AutoColumns
 }


### PR DESCRIPTION
sqlboiler users who call it as a library rather than an executable can now add a `template.FuncMap` to their config objects which will be available in the templates under UserFuncs.

Allows advanced users to extend their templates further without needing to fork sqlboiler itself.