### PR TITLE
QuoteWrap columns in many-to-many eager join

### DIFF
--- a/boilingcore/templates.go
+++ b/boilingcore/templates.go
@@ -248,6 +248,7 @@ func (o once) Put(s string) bool {
 var templateStringMappers = map[string]func(string) string{
 	// String ops
 	"quoteWrap":       func(a string) string { return fmt.Sprintf(`"%s"`, a) },
+	"safeQuoteWrap":   func(a string) string { return fmt.Sprintf(`\"%s\"`, a) },
 	"replaceReserved": strmangle.ReplaceReservedWords,
 
 	// Casing
@@ -262,9 +263,10 @@ var goVarnameReplacer = strings.NewReplacer("[", "_", "]", "_", ".", "_")
 // add a function pointer here.
 var templateFunctions = template.FuncMap{
 	// String ops
-	"quoteWrap": func(s string) string { return fmt.Sprintf(`"%s"`, s) },
-	"id":        strmangle.Identifier,
-	"goVarname": goVarnameReplacer.Replace,
+	"quoteWrap":     func(s string) string { return fmt.Sprintf(`"%s"`, s) },
+	"safeQuoteWrap": func(a string) string { return fmt.Sprintf(`\"%s\"`, a) },
+	"id":            strmangle.Identifier,
+	"goVarname":     goVarnameReplacer.Replace,
 
 	// Pluralization
 	"singular": strmangle.Singular,

--- a/templates/main/09_relationship_to_many_eager.go.tpl
+++ b/templates/main/09_relationship_to_many_eager.go.tpl
@@ -57,7 +57,7 @@ func ({{$ltable.DownSingular}}L) Load{{$relAlias.Local}}({{if $.NoContext}}e boi
 			{{- $schemaJoinTable := .JoinTable | $.SchemaTable -}}
 			{{- $foreignTable := getTable $.Tables .ForeignTable -}}
 	query := NewQuery(
-		qm.Select("{{$foreignTable.Columns | columnNames | stringMap .StringFuncs.quoteWrap | prefixStringSlice (print $schemaForeignTable ".") | join ", "}}, {{id 0 | $.Quotes}}.{{.JoinLocalColumn | $.Quotes}}"),
+		qm.Select("{{$foreignTable.Columns | columnNames | stringMap $.StringFuncs.safeQuoteWrap | prefixStringSlice (print $schemaForeignTable ".") | join ", "}}, {{id 0 | $.Quotes}}.{{.JoinLocalColumn | $.Quotes}}"),
 		qm.From("{{$schemaForeignTable}}"),
 		qm.InnerJoin("{{$schemaJoinTable}} as {{id 0 | $.Quotes}} on {{$schemaForeignTable}}.{{.ForeignColumn | $.Quotes}} = {{id 0 | $.Quotes}}.{{.JoinForeignColumn | $.Quotes}}"),
 		qm.WhereIn("{{id 0 | $.Quotes}}.{{.JoinLocalColumn | $.Quotes}} in ?", args...),

--- a/templates/main/09_relationship_to_many_eager.go.tpl
+++ b/templates/main/09_relationship_to_many_eager.go.tpl
@@ -57,7 +57,7 @@ func ({{$ltable.DownSingular}}L) Load{{$relAlias.Local}}({{if $.NoContext}}e boi
 			{{- $schemaJoinTable := .JoinTable | $.SchemaTable -}}
 			{{- $foreignTable := getTable $.Tables .ForeignTable -}}
 	query := NewQuery(
-		qm.Select("{{$foreignTable.Columns | columnNames | prefixStringSlice (print $schemaForeignTable ".") | join ", "}}, {{id 0 | $.Quotes}}.{{.JoinLocalColumn | $.Quotes}}"),
+		qm.Select("{{$foreignTable.Columns | columnNames | stringMap .StringFuncs.quoteWrap | prefixStringSlice (print $schemaForeignTable ".") | join ", "}}, {{id 0 | $.Quotes}}.{{.JoinLocalColumn | $.Quotes}}"),
 		qm.From("{{$schemaForeignTable}}"),
 		qm.InnerJoin("{{$schemaJoinTable}} as {{id 0 | $.Quotes}} on {{$schemaForeignTable}}.{{.ForeignColumn | $.Quotes}} = {{id 0 | $.Quotes}}.{{.JoinForeignColumn | $.Quotes}}"),
 		qm.WhereIn("{{id 0 | $.Quotes}}.{{.JoinLocalColumn | $.Quotes}} in ?", args...),

--- a/testdata/psql_test_schema.sql
+++ b/testdata/psql_test_schema.sql
@@ -2,6 +2,7 @@ CREATE EXTENSION IF NOT EXISTS citext;
 
 CREATE TYPE workday AS ENUM('monday', 'tuesday', 'wednesday', 'thursday', 'friday');
 CREATE TYPE faceyface AS ENUM('angry', 'hungry', 'bitter');
+CREATE TYPE "UserRole" AS ENUM ('SUPER_ADMIN', 'BILLING_ADMIN', 'READ_ONLY_ADMIN', 'USER');
 
 CREATE TABLE event_one (
   id     serial PRIMARY KEY NOT NULL,
@@ -440,4 +441,17 @@ ALTER TABLE pilot_languages ADD CONSTRAINT languages_fkey FOREIGN KEY (language_
 -- Previously the generated code had a naming clash when a table was called 'updates'
 CREATE TABLE updates (
     id integer PRIMARY KEY NOT NULL
+);
+
+-- Create table that has a name with an uppercase letter and columns with uppercase letters
+CREATE TABLE "User" (
+    "id" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "userId" VARCHAR(127) NOT NULL,
+    "role" "UserRole" NOT NULL DEFAULT E'USER',
+    "tenantId" UUID NOT NULL,
+    "clientId" UUID,
+
+    PRIMARY KEY ("id")
 );


### PR DESCRIPTION
Handle condition where the to-many select statement was not wrapping columns in quotes. I followed the pattern established by `templates/main/01_types.go.tpl`, so I have a high level of confidence this is the right solution.

I also added a new Enum and Table to the `testdata/psql_test_schema.sql` file so we can catch errors like this in the future.