### PR TITLE
allow user supplied base templates

### DIFF
--- a/boilingcore/boilingcore.go
+++ b/boilingcore/boilingcore.go
@@ -227,7 +227,7 @@ func (s *State) Cleanup() error {
 func (s *State) initTemplates() ([]lazyTemplate, error) {
 	var err error
 
-	defaultTemplates := s.Config.BaseTemplates
+	defaultTemplates := s.Config.DefaultTemplates
 	if defaultTemplates == nil {
 		defaultTemplates = boiltemplates.Builtin
 	}

--- a/boilingcore/boilingcore.go
+++ b/boilingcore/boilingcore.go
@@ -227,11 +227,6 @@ func (s *State) Cleanup() error {
 func (s *State) initTemplates() ([]lazyTemplate, error) {
 	var err error
 
-	defaultTemplates := s.Config.DefaultTemplates
-	if defaultTemplates == nil {
-		defaultTemplates = boiltemplates.Builtin
-	}
-
 	templates := make(map[string]templateLoader)
 	if len(s.Config.TemplateDirs) != 0 {
 		for _, dir := range s.Config.TemplateDirs {
@@ -250,6 +245,11 @@ func (s *State) initTemplates() ([]lazyTemplate, error) {
 			mergeTemplates(templates, tpls)
 		}
 	} else {
+		defaultTemplates := s.Config.DefaultTemplates
+		if defaultTemplates == nil {
+			defaultTemplates = boiltemplates.Builtin
+		}
+
 		err := fs.WalkDir(defaultTemplates, ".", func(path string, entry fs.DirEntry, err error) error {
 			if err != nil {
 				return err

--- a/boilingcore/config.go
+++ b/boilingcore/config.go
@@ -40,8 +40,8 @@ type Config struct {
 	RelationTag       string   `toml:"relation_tag,omitempty" json:"relation_tag,omitempty"`
 	TagIgnore         []string `toml:"tag_ignore,omitempty" json:"tag_ignore,omitempty"`
 
-	Imports       importers.Collection `toml:"imports,omitempty" json:"imports,omitempty"`
-	BaseTemplates fs.FS                `toml:"-" json:"-"`
+	Imports          importers.Collection `toml:"imports,omitempty" json:"imports,omitempty"`
+	DefaultTemplates fs.FS                `toml:"-" json:"-"`
 
 	Aliases      Aliases       `toml:"aliases,omitempty" json:"aliases,omitempty"`
 	TypeReplaces []TypeReplace `toml:"type_replaces,omitempty" json:"type_replaces,omitempty"`

--- a/boilingcore/config.go
+++ b/boilingcore/config.go
@@ -1,6 +1,7 @@
 package boilingcore
 
 import (
+	"io/fs"
 	"path/filepath"
 	"strings"
 
@@ -39,7 +40,8 @@ type Config struct {
 	RelationTag       string   `toml:"relation_tag,omitempty" json:"relation_tag,omitempty"`
 	TagIgnore         []string `toml:"tag_ignore,omitempty" json:"tag_ignore,omitempty"`
 
-	Imports importers.Collection `toml:"imports,omitempty" json:"imports,omitempty"`
+	Imports       importers.Collection `toml:"imports,omitempty" json:"imports,omitempty"`
+	BaseTemplates fs.FS                `toml:"-" json:"-"`
 
 	Aliases      Aliases       `toml:"aliases,omitempty" json:"aliases,omitempty"`
 	TypeReplaces []TypeReplace `toml:"type_replaces,omitempty" json:"type_replaces,omitempty"`


### PR DESCRIPTION
This allows wrapper CLIs to easily override the base templates instead of having to create a temporary directory and supplying the path