### PR TITLE
Make the join query unique

### DIFF
--- a/queries/query.go
+++ b/queries/query.go
@@ -303,21 +303,49 @@ func SetFrom(q *Query, from ...string) {
 
 // AppendInnerJoin on the query.
 func AppendInnerJoin(q *Query, clause string, args ...interface{}) {
+	if len(args) == 0 {
+		for _, j := range q.joins {
+			if j.clause == clause && j.kind == JoinInner {
+				return
+			}
+		}
+	}
 	q.joins = append(q.joins, join{clause: clause, kind: JoinInner, args: args})
 }
 
 // AppendLeftOuterJoin on the query.
 func AppendLeftOuterJoin(q *Query, clause string, args ...interface{}) {
+	if len(args) == 0 {
+		for _, j := range q.joins {
+			if j.clause == clause && j.kind == JoinOuterLeft {
+				return
+			}
+		}
+	}
 	q.joins = append(q.joins, join{clause: clause, kind: JoinOuterLeft, args: args})
 }
 
 // AppendRightOuterJoin on the query.
 func AppendRightOuterJoin(q *Query, clause string, args ...interface{}) {
+	if len(args) == 0 {
+		for _, j := range q.joins {
+			if j.clause == clause && j.kind == JoinOuterRight {
+				return
+			}
+		}
+	}
 	q.joins = append(q.joins, join{clause: clause, kind: JoinOuterRight, args: args})
 }
 
 // AppendFullOuterJoin on the query.
 func AppendFullOuterJoin(q *Query, clause string, args ...interface{}) {
+	if len(args) == 0 {
+		for _, j := range q.joins {
+			if j.clause == clause && j.kind == JoinOuterFull {
+				return
+			}
+		}
+	}
 	q.joins = append(q.joins, join{clause: clause, kind: JoinOuterFull, args: args})
 }
 


### PR DESCRIPTION
Due to db specifications, only one join with the same alias can be specified for the same table.

Therefore, when a query with the same join is specified, we have added the ability to pass through one of the joins.

By adding this, we are happy to be able to specify a join without db error even if the query is dynamically created in multiple places.