### PR TITLE
parsePoint(s) regexp.MustCompile is now called only once

### DIFF
--- a/types/pgeo/general.go
+++ b/types/pgeo/general.go
@@ -51,11 +51,13 @@ func formatPoints(points []Point) string {
 	return strings.Join(pts, ",")
 }
 
+var parsePointRegexp = regexp.MustCompile(`^\((-?[0-9]+(?:\.[0-9]+)?),(-?[0-9]+(?:\.[0-9]+)?)\)$`)
+
 func parsePoint(pt string) (Point, error) {
 	var point = Point{}
 	var err error
 
-	pdzs := regexp.MustCompile(`^\((-?[0-9]+(?:\.[0-9]+)?),(-?[0-9]+(?:\.[0-9]+)?)\)$`).FindStringSubmatch(pt)
+	pdzs := parsePointRegexp.FindStringSubmatch(pt)
 	if len(pdzs) != 3 {
 		return point, errors.New("wrong point")
 	}
@@ -71,10 +73,12 @@ func parsePoint(pt string) (Point, error) {
 	return point, nil
 }
 
+var parsePointsRegexp = regexp.MustCompile(`\((?:-?[0-9]+(?:\.[0-9]+)?),(?:-?[0-9]+(?:\.[0-9]+)?)\)`)
+
 func parsePoints(pts string) ([]Point, error) {
 	var points = []Point{}
 
-	pdzs := regexp.MustCompile(`\((?:-?[0-9]+(?:\.[0-9]+)?),(?:-?[0-9]+(?:\.[0-9]+)?)\)`).FindAllString(pts, -1)
+	pdzs := parsePointsRegexp.FindAllString(pts, -1)
 	for _, pt := range pdzs {
 		point, err := parsePoint(pt)
 		if err != nil {

--- a/types/pgeo/general_test.go
+++ b/types/pgeo/general_test.go
@@ -1,0 +1,15 @@
+package pgeo
+
+import (
+	"testing"
+)
+
+func BenchmarkParsePoint(b *testing.B) {
+	pString := "(-13.735219157895635,-72.7159127785469)"
+	for i := 0; i < 100000; i++ {
+		_, err := parsePoint(pString)
+		if err != nil {
+			b.Error("parsePoint failed", err)
+		}
+	}
+}


### PR DESCRIPTION
Scanning a GeoPoint used to transitively call `regexp.MustCompile`. This leads to unnecessary memory allocations and therefore substantial GC runs which leads to high CPU usage. 

This PR extracts regular expression compile step to be performed only once. Performance is improved as the benchmarks show.

<img width="523" alt="Screenshot 2022-04-13 at 11 56 52" src="https://user-images.githubusercontent.com/654254/163140648-3891c456-2b91-43f5-84cf-0a23052b81f3.png">
