### PR TITLE
Fix one single point in paths and polygons

### DIFF
--- a/types/pgeo/line.go
+++ b/types/pgeo/line.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 )
 
+var parseLineRegexp = regexp.MustCompile(`^\{(-?[0-9]+(?:\.[0-9]+)?),(-?[0-9]+(?:\.[0-9]+)?),(-?[0-9]+(?:\.[0-9]+)?)\}$`)
+
 // Line represents a infinite line with the linear equation Ax + By + C = 0, where A and B are not both zero.
 type Line struct {
 	A float64 `json:"a"`
@@ -39,7 +41,7 @@ func scanLine(l *Line, src interface{}) error {
 		return err
 	}
 
-	pdzs := regexp.MustCompile(`^\{(-?[0-9]+(?:\.[0-9]+)?),(-?[0-9]+(?:\.[0-9]+)?),(-?[0-9]+(?:\.[0-9]+)?)\}$`).FindStringSubmatch(val)
+	pdzs := parseLineRegexp.FindStringSubmatch(val)
 	if len(pdzs) != 4 {
 		return errors.New("wrong line")
 	}

--- a/types/pgeo/path.go
+++ b/types/pgeo/path.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 )
 
+var closedPathRegexp = regexp.MustCompile(`^\(\(`)
+
 // Path is represented by lists of connected points.
 // Paths can be open, where the first and last points in the list are considered not connected,
 // or closed, where the first and last points are considered connected.
@@ -50,11 +52,11 @@ func scanPath(p *Path, src interface{}) error {
 		return err
 	}
 
-	if len((*p).Points) < 2 {
+	if len((*p).Points) < 1 {
 		return errors.New("wrong path")
 	}
 
-	(*p).Closed = regexp.MustCompile(`^\(\(`).MatchString(val)
+	(*p).Closed = closedPathRegexp.MatchString(val)
 
 	return nil
 }

--- a/types/pgeo/polygon.go
+++ b/types/pgeo/polygon.go
@@ -34,7 +34,7 @@ func scanPolygon(p *Polygon, src interface{}) error {
 		return err
 	}
 
-	if len(*p) <= 1 {
+	if len(*p) < 1 {
 		return errors.New("wrong polygon")
 	}
 

--- a/types/pgeo/polygon.go
+++ b/types/pgeo/polygon.go
@@ -34,7 +34,7 @@ func scanPolygon(p *Polygon, src interface{}) error {
 		return err
 	}
 
-	if len(*p) <= 2 {
+	if len(*p) <= 1 {
 		return errors.New("wrong polygon")
 	}
 


### PR DESCRIPTION
By checking https://github.com/volatiletech/sqlboiler/issues/994 I confirm that Postgres allow paths and polygons consistent of one single point. So the previous assumption that it should be at least two points was wrong.

Also two regexp are now called once.