### PR TITLE
Add getter methods to relationship structs

### DIFF
--- a/templates/main/00_struct.go.tpl
+++ b/templates/main/00_struct.go.tpl
@@ -164,6 +164,42 @@ func (*{{$alias.DownSingular}}R) NewStruct() *{{$alias.DownSingular}}R {
 	return &{{$alias.DownSingular}}R{}
 }
 
+{{range .Table.FKeys -}}
+{{- $ftable := $.Aliases.Table .ForeignTable -}}
+{{- $relAlias := $alias.Relationship .Name -}}
+func (r *{{$alias.DownSingular}}R) Get{{$relAlias.Foreign}}() *{{$ftable.UpSingular}} {
+	if (r == nil) {
+    return nil
+	}
+  return r.{{$relAlias.Foreign}}
+}
+
+{{end -}}
+
+{{- range .Table.ToOneRelationships -}}
+{{- $ftable := $.Aliases.Table .ForeignTable -}}
+{{- $relAlias := $ftable.Relationship .Name -}}
+func (r *{{$alias.DownSingular}}R) Get{{$relAlias.Local}}() *{{$ftable.UpSingular}} {
+	if (r == nil) {
+    return nil
+	}
+  return r.{{$relAlias.Local}}
+}
+
+{{end -}}
+
+{{- range .Table.ToManyRelationships -}}
+{{- $ftable := $.Aliases.Table .ForeignTable -}}
+{{- $relAlias := $.Aliases.ManyRelationship .ForeignTable .Name .JoinTable .JoinLocalFKeyName -}}
+func (r *{{$alias.DownSingular}}R) Get{{$relAlias.Local}}() {{printf "%sSlice" $ftable.UpSingular}} {
+	if (r == nil) {
+    return nil
+	}
+  return r.{{$relAlias.Local}}
+}
+
+{{end -}}
+
 // {{$alias.DownSingular}}L is where Load methods for each relationship are stored.
 type {{$alias.DownSingular}}L struct{}
 {{end -}}


### PR DESCRIPTION
The goal of this change is to alleviate the need for the caller to check
if the models' relationship struct is nil before accessing a field.
Indeed, we've seen a proliferation in our codebase of the following
pattern:

```
if record.R != nil && record.R.SomeField != nil {
   ...
}
```

This is especially required in utilities functions which are not
responsible for loading the model and can't know if the record has
eagerly loaded the relationships and thus can't know if the relationship
struct is nil. With this change, the previous code idiom can be replaced
with:

```
if field := record.R.GetSomeField(); field != nil {
  ...
}

```

The important part is that there's no possibility for panicing due to
nil pointer, where-as, previously,  if the caller forgot to check for
`record.R != nil`, a panic could happen.

The change is backward compatible and follows the pattern that protobuf
generation uses, i.e. `Message.GetX() XType`.