### PR TITLE
Fix some SQLite tests by enabling shared cache

### DIFF
--- a/drivers/sqlboiler-sqlite3/driver/override/test/singleton/sqlite3_main_test.go.tpl
+++ b/drivers/sqlboiler-sqlite3/driver/override/test/singleton/sqlite3_main_test.go.tpl
@@ -64,7 +64,7 @@ func (s *sqliteTester) conn() (*sql.DB, error) {
 	}
 
 	var err error
-	s.dbConn, err = sql.Open("sqlite", fmt.Sprintf("file:%s?_loc=UTC", s.testDBName))
+	s.dbConn, err = sql.Open("sqlite", fmt.Sprintf("file:%s?cache=shared&_loc=UTC", s.testDBName))
         if err != nil {
         return nil, err
 	}


### PR DESCRIPTION
Since tests are run in parallel and sqlite does not allow multiple inserts at once, tests generated for sqlite models currently fail with the following error:
```
--- FAIL: TestInsert (0.00s)
    --- FAIL: TestInsert/Files#01 (0.00s)
        files_test.go:585: models: unable to insert into files: database is locked (5) (SQLITE_BUSY)
        files_test.go:594: want one record, got: 0
```

This PR enables [shared cache](https://www.sqlite.org/sharedcache.html) during tests to resolve this.
I found other methods to resolve these errors in https://github.com/mattn/go-sqlite3/issues/274 including setting `_timeout` or setting a connection limit, but `cache=shared` was reliable for me and seems to otherwise increase performance.

This PR fixes one of the problems in #758, but may resolve all of them.