### PR TITLE
Fix panic when missing primary key in table

### DIFF
--- a/drivers/interface.go
+++ b/drivers/interface.go
@@ -227,6 +227,10 @@ func knownColumn(table string, column string, whitelist, blacklist []string) boo
 
 // filterPrimaryKey filter columns from the primary key that are not in whitelist or in blacklist
 func filterPrimaryKey(t *Table, whitelist, blacklist []string) {
+	if t.PKey == nil {
+		return
+	}
+
 	pkeyColumns := make([]string, 0, len(t.PKey.Columns))
 	for _, c := range t.PKey.Columns {
 		if knownColumn(t.Name, c, whitelist, blacklist) {


### PR DESCRIPTION
Fix a regression I introduced in https://github.com/volatiletech/sqlboiler/pull/1126 where the codegen would panic on tables without primary key by adding a nil check for t.PKey. Now it properly errors with the expected message:
```
Error: unable to initialize tables: primary key missing in tables (blogs)
```

Fixes https://github.com/volatiletech/sqlboiler/issues/1132