### PR TITLE
Trim whitespace for column comments

### DIFF
--- a/boilingcore/templates.go
+++ b/boilingcore/templates.go
@@ -319,7 +319,7 @@ var templateFunctions = template.FuncMap{
 		if a == "" {
 			return nil
 		}
-		return strings.Split(a, "\n")
+		return strings.Split(strings.TrimSpace(a), "\n")
 	},
 
 	// dbdrivers ops


### PR DESCRIPTION
The PostgreSQL syntax for setting a comment is:

	comment on column tbl.col is 'My comment!';

That's all fine, but as far as I can find you can't really escape
newlines in the string or use functions like substr() to remove that
first newline, so something like this:

	comment on column tbl.col is '
	My comment is long and spans multiple lines.

	It continues over here.';

Generates:

	//
	// My comment is long and spans multiple lines.
	//
	// It continues over here.

You could do:

	comment on column tbl.col is 'My comment is long and spans multiple lines.

	It continues over here.';

But this is pretty annoying/awkward, and it's hard to maintain a
consistent line length like this.

So trim the whitespace at the start and end, which generally makes
things less finicky, and I can't really think of a scenario where you
ever want to keep this.