### PR TITLE
Loading model relationships when binding to a struct with embedded model

### DIFF
--- a/templates/main/07_relationship_to_one_eager.go.tpl
+++ b/templates/main/07_relationship_to_one_eager.go.tpl
@@ -16,9 +16,25 @@ func ({{$ltable.DownSingular}}L) Load{{$rel.Foreign}}({{if $.NoContext}}e boil.E
 	var object *{{$ltable.UpSingular}}
 
 	if singular {
-		object = {{$arg}}.(*{{$ltable.UpSingular}})
+		var ok bool
+		object, ok = {{$arg}}.(*{{$ltable.UpSingular}})
+		if !ok {
+			object = new({{$ltable.UpSingular}})
+			ok = queries.SetFromEmbeddedStruct(&object, &{{$arg}})
+			if !ok {
+				return errors.New(fmt.Sprintf("failed to set %T from embedded struct %T", object, {{$arg}}))
+			}
+		}
 	} else {
-		slice = *{{$arg}}.(*[]*{{$ltable.UpSingular}})
+		s, ok := {{$arg}}.(*[]*{{$ltable.UpSingular}})
+		if ok {
+			slice = *s
+		} else {
+			ok = queries.SetFromEmbeddedStruct(&slice, {{$arg}})
+			if !ok {
+				return errors.New(fmt.Sprintf("failed to set %T from embedded struct %T", slice, {{$arg}}))
+			}
+		}
 	}
 
 	args := make([]interface{}, 0, 1)

--- a/templates/main/08_relationship_one_to_one_eager.go.tpl
+++ b/templates/main/08_relationship_one_to_one_eager.go.tpl
@@ -16,9 +16,25 @@ func ({{$ltable.DownSingular}}L) Load{{$relAlias.Local}}({{if $.NoContext}}e boi
 	var object *{{$ltable.UpSingular}}
 
 	if singular {
-		object = {{$arg}}.(*{{$ltable.UpSingular}})
+		var ok bool
+		object, ok = {{$arg}}.(*{{$ltable.UpSingular}})
+		if !ok {
+			object = new({{$ltable.UpSingular}})
+			ok = queries.SetFromEmbeddedStruct(&object, &{{$arg}})
+			if !ok {
+				return errors.New(fmt.Sprintf("failed to set %T from embedded struct %T", object, {{$arg}}))
+			}
+		}
 	} else {
-		slice = *{{$arg}}.(*[]*{{$ltable.UpSingular}})
+		s, ok := {{$arg}}.(*[]*{{$ltable.UpSingular}})
+		if ok {
+			slice = *s
+		} else {
+			ok = queries.SetFromEmbeddedStruct(&slice, {{$arg}})
+			if !ok {
+				return errors.New(fmt.Sprintf("failed to set %T from embedded struct %T", slice, {{$arg}}))
+			}
+		}
 	}
 
 	args := make([]interface{}, 0, 1)

--- a/templates/main/09_relationship_to_many_eager.go.tpl
+++ b/templates/main/09_relationship_to_many_eager.go.tpl
@@ -17,9 +17,25 @@ func ({{$ltable.DownSingular}}L) Load{{$relAlias.Local}}({{if $.NoContext}}e boi
 	var object *{{$ltable.UpSingular}}
 
 	if singular {
-		object = {{$arg}}.(*{{$ltable.UpSingular}})
+		var ok bool
+		object, ok = {{$arg}}.(*{{$ltable.UpSingular}})
+		if !ok {
+			object = new({{$ltable.UpSingular}})
+			ok = queries.SetFromEmbeddedStruct(&object, &{{$arg}})
+			if !ok {
+				return errors.New(fmt.Sprintf("failed to set %T from embedded struct %T", object, {{$arg}}))
+			}
+		}
 	} else {
-		slice = *{{$arg}}.(*[]*{{$ltable.UpSingular}})
+		s, ok := {{$arg}}.(*[]*{{$ltable.UpSingular}})
+		if ok {
+			slice = *s
+		} else {
+			ok = queries.SetFromEmbeddedStruct(&slice, {{$arg}})
+			if !ok {
+				return errors.New(fmt.Sprintf("failed to set %T from embedded struct %T", slice, {{$arg}}))
+			}
+		}
 	}
 
 	args := make([]interface{}, 0, 1)


### PR DESCRIPTION
This PR addresses the issue described in #1158.
In case when `Bind()` is used with a struct that contains embedded model field, model's `Load*` methods will panic because types do not match.
Only in this case the reflection is used to find the embedded field(s) of the same type as model and save it's pointer(s) to the model `object`/`slice` already allocated in `Load*` methods.

It's not the most elegant solution, but it works without breaking backward compatibility and doesn't require to rewrite the query builder.