### PR TITLE
Allocate struct pointers fields with "bind" tag

### DIFF
--- a/queries/reflect.go
+++ b/queries/reflect.go
@@ -251,7 +251,7 @@ Rows:
 		case kindSliceStruct:
 			pointers = PtrsFromMapping(oneStruct, mapping)
 		case kindPtrSliceStruct:
-			newStruct = reflect.New(structType)
+			newStruct = makeStructPtr(structType)
 			pointers = PtrsFromMapping(reflect.Indirect(newStruct), mapping)
 		}
 		if err != nil {
@@ -277,6 +277,27 @@ Rows:
 	}
 
 	return nil
+}
+
+// makeStructPtr takes a struct type and returns a pointer to a new instance of it. This is used by bind to allocate new
+// slice elements when the bound-to variable is []*Struct
+func makeStructPtr(typ reflect.Type) reflect.Value {
+	// Allocate struct
+	val := reflect.New(typ)
+
+	// For all the fields
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		_, recurse := getBoilTag(field)
+
+		// If ",bind" was in the tag and the field is a pointer
+		if recurse && field.Type.Kind() == reflect.Ptr {
+			// Then allocate the field
+			val.Elem().Field(i).Set(reflect.New(field.Type.Elem()))
+		}
+	}
+
+	return val
 }
 
 // BindMapping creates a mapping that helps look up the pointer for the


### PR DESCRIPTION
Hello,
this is an attempt to fix #1164.

If I were to do something like:
```go
var slice []*struct{
    User *models.User `boil:",bind"`
}
models.Users().BindG(nil, &slice)
```

It wouldn't have worked prior to this PR because `bind` would've created a zeroed instance of the struct and then attempted to get a `reflect.Value` by dereferencing the `User` field. But in a zeroed struct the pointer is nil, and so you get this panic:

```
panic: reflect: call of reflect.Value.Field on zero Value
```

A workaround would be to embed `models.User` without a pointer. But this is not always feasible or performant, depending on how the resulting slice is going to be used afterward.

This PR makes it so that `bind` also allocates any pointer field provided that the target is `[]*Struct` and the `bind` tag is set.

---

Implementation wise, I simply enumerate the struct fields after the call to `reflect.New` and allocate any pointer with the `bind` tag.

When the `bind` target is `[]Struct` (instead of `[]*Struct`) the behavior remains unchanged as the structs are copied-by-value anyways and the [documentation](https://pkg.go.dev/github.com/volatiletech/sqlboiler/v4/queries#Bind) already warns about not using structs with references when binding like that.