### PR TITLE
Fix Load templates checking the wrong hooks

### DIFF
--- a/templates/main/07_relationship_to_one_eager.go.tpl
+++ b/templates/main/07_relationship_to_one_eager.go.tpl
@@ -113,7 +113,7 @@ func ({{$ltable.DownSingular}}L) Load{{$rel.Foreign}}({{if $.NoContext}}e boil.E
 	}
 
 	{{if not $.NoHooks -}}
-	if len({{$ltable.DownSingular}}AfterSelectHooks) != 0 {
+	if len({{$ftable.DownSingular}}AfterSelectHooks) != 0 {
 		for _, obj := range resultSlice {
 			if err := obj.doAfterSelectHooks({{if $.NoContext}}e{{else}}ctx, e{{end}}); err != nil {
 				return err

--- a/templates/main/08_relationship_one_to_one_eager.go.tpl
+++ b/templates/main/08_relationship_one_to_one_eager.go.tpl
@@ -101,7 +101,7 @@ func ({{$ltable.DownSingular}}L) Load{{$relAlias.Local}}({{if $.NoContext}}e boi
 	}
 
 	{{if not $.NoHooks -}}
-	if len({{$ltable.DownSingular}}AfterSelectHooks) != 0 {
+	if len({{$ftable.DownSingular}}AfterSelectHooks) != 0 {
 		for _, obj := range resultSlice {
 			if err := obj.doAfterSelectHooks({{if $.NoContext}}e{{else}}ctx, e{{end}}); err != nil {
 				return err

--- a/templates/test/relationship_one_to_one.go.tpl
+++ b/templates/test/relationship_one_to_one.go.tpl
@@ -49,6 +49,14 @@ func test{{$ltable.UpSingular}}OneToOne{{$ftable.UpSingular}}Using{{$relAlias.Lo
 		t.Errorf("want: %v, got %v", foreign.{{$fcolField}}, check.{{$fcolField}})
 	}
 
+	{{if not $.NoHooks -}}
+	ranAfterSelectHook := false
+	Add{{$ftable.UpSingular}}Hook(boil.AfterSelectHook, func({{if not $.NoContext}}ctx context.Context, {{end}}e boil.ContextExecutor, o *{{$ftable.UpSingular}}) error {
+		ranAfterSelectHook = true
+		return nil
+	})
+	{{- end}}
+
 	slice := {{$ltable.UpSingular}}Slice{&local}
 	if err = local.L.Load{{$relAlias.Local}}({{if not $.NoContext}}ctx, {{end -}} tx, false, (*[]*{{$ltable.UpSingular}})(&slice), nil); err != nil {
 		t.Fatal(err)
@@ -64,6 +72,12 @@ func test{{$ltable.UpSingular}}OneToOne{{$ftable.UpSingular}}Using{{$relAlias.Lo
 	if local.R.{{$relAlias.Local}} == nil {
 		t.Error("struct should have been eager loaded")
 	}
+
+	{{if not $.NoHooks -}}
+	if !ranAfterSelectHook {
+		t.Error("failed to run AfterSelect hook for relationship")
+	}
+	{{- end}}
 }
 
 {{end -}}{{/* range */}}

--- a/templates/test/relationship_to_one.go.tpl
+++ b/templates/test/relationship_to_one.go.tpl
@@ -49,6 +49,14 @@ func test{{$ltable.UpSingular}}ToOne{{$ftable.UpSingular}}Using{{$rel.Foreign}}(
 		t.Errorf("want: %v, got %v", foreign.{{$fcolField}}, check.{{$fcolField}})
 	}
 
+	{{if not $.NoHooks -}}
+	ranAfterSelectHook := false
+	Add{{$ftable.UpSingular}}Hook(boil.AfterSelectHook, func({{if not $.NoContext}}ctx context.Context, {{end}}e boil.ContextExecutor, o *{{$ftable.UpSingular}}) error {
+		ranAfterSelectHook = true
+		return nil
+	})
+	{{- end}}
+
 	slice := {{$ltable.UpSingular}}Slice{&local}
 	if err = local.L.Load{{$rel.Foreign}}({{if not $.NoContext}}ctx, {{end -}} tx, false, (*[]*{{$ltable.UpSingular}})(&slice), nil); err != nil {
 		t.Fatal(err)
@@ -64,6 +72,12 @@ func test{{$ltable.UpSingular}}ToOne{{$ftable.UpSingular}}Using{{$rel.Foreign}}(
 	if local.R.{{$rel.Foreign}} == nil {
 		t.Error("struct should have been eager loaded")
 	}
+
+	{{if not $.NoHooks -}}
+	if !ranAfterSelectHook {
+		t.Error("failed to run AfterSelect hook for relationship")
+	}
+	{{- end}}
 }
 
 {{end -}}{{/* range */}}


### PR DESCRIPTION
`relationship_to_many` was already doing this correctly, but to_one was not.

Fixes #1185 