### PR TITLE
Small Change: Allow calling struct.Exists() without having to pass on PK fields

### DIFF
--- a/templates/main/20_exists.go.tpl
+++ b/templates/main/20_exists.go.tpl
@@ -76,4 +76,9 @@ func {{$alias.UpSingular}}Exists({{if .NoContext}}exec boil.Executor{{else}}ctx 
 	return exists, nil
 }
 
+// Exists checks if the {{$alias.UpSingular}} row exists.
+func (o *{{$alias.UpSingular}}) Exists({{if .NoContext}}exec boil.Executor{{else}}ctx context.Context, exec boil.ContextExecutor{{end}}) (bool, error) {
+	return {{$alias.UpSingular}}Exists({{if .NoContext}}exec{{else}}ctx, exec{{end}}, o.{{$.Table.PKey.Columns | stringMap (aliasCols $alias) | join ", o."}})
+}
+
 {{- end -}}


### PR DESCRIPTION
For when having a helper interface that has Insert(), Update() and Upsert().  
Upsert() is not always possible, e.g. if table has composite PK.  

An alternative is necessary. Therefore, knowing whether the record exists helps to decide between Insert() and Update().

This enables e.g. generic mass loads from external files.

```
type DBHelper interface {
	Exists(ctx context.Context, exec boil.ContextExecutor) (bool, error)
	Insert(ctx context.Context, exec boil.ContextExecutor, columns boil.Columns) error
	Update(ctx context.Context, exec boil.ContextExecutor, columns boil.Columns) (int64, error)
	Upsert(ctx context.Context, exec boil.ContextExecutor, updateColumns, insertColumns boil.Columns) error
} 
```

Workaround for #328, if you e.g. flag upsert-incompatible tables and use interface such as above.


## Example

troublesome table in question
```
CREATE TABLE LanguageText (
    lang_id         CHAR(3) NOT NULL COMMENT 'ISO 639-3 Code', -- "eng"
    localization_id CHAR(3) NOT NULL COMMENT 'ISO 639-3 Code', -- "deu"

    text CHAR(20) NOT NULL,

    PRIMARY KEY (lang_id,localization_id),
    CONSTRAINT languagetext_language_fk_1
        FOREIGN KEY (lang_id) REFERENCES Language (id)
        ON DELETE RESTRICT
        ON UPDATE RESTRICT,
    CONSTRAINT languagetext_language_fk_2
        FOREIGN KEY (localization_id) REFERENCES Language (id)
        ON DELETE RESTRICT
        ON UPDATE RESTRICT
);
```

result of template execution
```
// Exists checks if the LanguageText row exists.
func (o *LanguageText) Exists(ctx context.Context, exec boil.ContextExecutor) (bool, error) {
	return LanguageTextExists(ctx, exec, o.LangID, o.LocalizationID)
}
```