### PR TITLE
fix an Example in Query Mod System

### DIFF
--- a/README.md
+++ b/README.md
@@ -1177,12 +1177,12 @@ Or("height=?", 183)
 
 Where("(name=? and age=?) or (age=?)", "John", 5, 6)
 // Expr allows manual grouping of statements
-Where(
+Expr(
   Expr(
     models.PilotWhere.Name.EQ("John"),
-    Or2(models.PilotWhere.Age.EQ(5)),
+    models.PilotWhere.Age.EQ(5),
   ),
-  Or2(models.PilotAge),
+  Or2(models.PilotWhere.Age.EQ(6)),
 )
 
 // WHERE IN clause building


### PR DESCRIPTION
I fixed as follows:
* I replaced `Where` with `Expr` in the example of `Expr` because the `Where` function does not take value of type not `string` as a first argument.
* I also modified the example of `Expr` because that does not correspond to the example `Where("(name=? and age=?) or (age=?)", "John", 5, 6)`.