### PR TITLE
Stop using the methods from io/ioutil as they are deprecated since Go 1.16

### DIFF
--- a/boilingcore/boilingcore_test.go
+++ b/boilingcore/boilingcore_test.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -62,7 +61,7 @@ func testNew(t *testing.T, aliases Aliases) {
 	}
 
 	var err error
-	out, err := ioutil.TempDir("", "boil_templates")
+	out, err := os.MkdirTemp("", "boil_templates")
 	if err != nil {
 		t.Fatalf("unable to create tempdir: %s", err)
 	}

--- a/boilingcore/output.go
+++ b/boilingcore/output.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"go/format"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -42,7 +41,7 @@ var (
 	rgxRemoveNumberedPrefix = regexp.MustCompile(`^[0-9]+_`)
 	rgxSyntaxError          = regexp.MustCompile(`(\d+):\d+: `)
 
-	testHarnessWriteFile = ioutil.WriteFile
+	testHarnessWriteFile = os.WriteFile
 )
 
 type executeTemplateData struct {

--- a/boilingcore/templates.go
+++ b/boilingcore/templates.go
@@ -6,7 +6,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -175,7 +175,7 @@ type fileLoader string
 
 func (f fileLoader) Load() ([]byte, error) {
 	fname := string(f)
-	b, err := ioutil.ReadFile(fname)
+	b, err := os.ReadFile(fname)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to load template: %s", fname)
 	}

--- a/drivers/binary_driver_test.go
+++ b/drivers/binary_driver_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"runtime"
 	"strings"
@@ -31,7 +31,7 @@ func TestBinaryDriver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	bin, err := ioutil.TempFile("", "test_binary_driver")
+	bin, err := os.CreateTemp("", "test_binary_driver")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +61,7 @@ func TestBinaryWarningDriver(t *testing.T) {
 		t.Skip("cannot run binary test on windows (needs bin/sh)")
 	}
 
-	bin, err := ioutil.TempFile("", "test_binary_driver")
+	bin, err := os.CreateTemp("", "test_binary_driver")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,7 +87,7 @@ func TestBinaryBadDriver(t *testing.T) {
 		t.Skip("cannot run binary test on windows (needs bin/sh)")
 	}
 
-	bin, err := ioutil.TempFile("", "test_binary_driver")
+	bin, err := os.CreateTemp("", "test_binary_driver")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/drivers/driver_main.go
+++ b/drivers/driver_main.go
@@ -3,7 +3,7 @@ package drivers
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 )
 
@@ -14,7 +14,7 @@ func DriverMain(driver Interface) {
 
 	switch method {
 	case "assemble":
-		b, err := ioutil.ReadAll(os.Stdin)
+		b, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "failed to read from stdin")
 			os.Exit(1)

--- a/drivers/sqlboiler-mssql/driver/mssql_test.go
+++ b/drivers/sqlboiler-mssql/driver/mssql_test.go
@@ -26,7 +26,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"flag"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"regexp"
@@ -92,7 +91,7 @@ func TestDriver(t *testing.T) {
 	}
 
 	if *flagOverwriteGolden {
-		if err = ioutil.WriteFile("mssql.golden.json", got, 0664); err != nil {
+		if err = os.WriteFile("mssql.golden.json", got, 0664); err != nil {
 			t.Fatal(err)
 		}
 		t.Log("wrote:", string(got))

--- a/drivers/sqlboiler-mssql/driver/mssql_test.go
+++ b/drivers/sqlboiler-mssql/driver/mssql_test.go
@@ -27,6 +27,7 @@ import (
 	"encoding/json"
 	"flag"
 	"io/ioutil"
+	"os"
 	"os/exec"
 	"regexp"
 	"testing"
@@ -98,7 +99,7 @@ func TestDriver(t *testing.T) {
 		return
 	}
 
-	want, err := ioutil.ReadFile("mssql.golden.json")
+	want, err := os.ReadFile("mssql.golden.json")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/drivers/sqlboiler-mysql/driver/mysql.go
+++ b/drivers/sqlboiler-mysql/driver/mysql.go
@@ -603,7 +603,6 @@ func (MySQLDriver) Imports() (col importers.Collection, err error) {
 				`"database/sql"`,
 				`"fmt"`,
 				`"io"`,
-				`"io/ioutil"`,
 				`"os"`,
 				`"os/exec"`,
 				`"regexp"`,

--- a/drivers/sqlboiler-mysql/driver/mysql_test.go
+++ b/drivers/sqlboiler-mysql/driver/mysql_test.go
@@ -15,6 +15,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"os/exec"
 	"testing"
 
@@ -33,7 +34,7 @@ var (
 )
 
 func TestDriver(t *testing.T) {
-	b, err := ioutil.ReadFile("testdatabase.sql")
+	b, err := os.ReadFile("testdatabase.sql")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,7 +106,7 @@ func TestDriver(t *testing.T) {
 				return
 			}
 
-			want, err := ioutil.ReadFile(tt.goldenJson)
+			want, err := os.ReadFile(tt.goldenJson)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/drivers/sqlboiler-mysql/driver/mysql_test.go
+++ b/drivers/sqlboiler-mysql/driver/mysql_test.go
@@ -14,7 +14,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"testing"
@@ -99,7 +98,7 @@ func TestDriver(t *testing.T) {
 			}
 
 			if *flagOverwriteGolden {
-				if err = ioutil.WriteFile(tt.goldenJson, got, 0664); err != nil {
+				if err = os.WriteFile(tt.goldenJson, got, 0664); err != nil {
 					t.Fatal(err)
 				}
 				t.Log("wrote:", string(got))

--- a/drivers/sqlboiler-mysql/driver/override/test/singleton/mysql_main_test.go.tpl
+++ b/drivers/sqlboiler-mysql/driver/override/test/singleton/mysql_main_test.go.tpl
@@ -120,7 +120,7 @@ func (m *mysqlTester) defaultsFile() string {
 }
 
 func (m *mysqlTester) makeOptionFile() error {
-	tmp, err := ioutil.TempFile("", "optionfile")
+	tmp, err := os.CreateTemp("", "optionfile")
 	if err != nil {
 		return errors.Wrap(err, "failed to create option file")
 	}

--- a/drivers/sqlboiler-psql/driver/override/test/singleton/psql_main_test.go.tpl
+++ b/drivers/sqlboiler-psql/driver/override/test/singleton/psql_main_test.go.tpl
@@ -141,7 +141,7 @@ func (p *pgTester) pgEnv() []string {
 }
 
 func (p *pgTester) makePGPassFile() error {
-	tmp, err := ioutil.TempFile("", "pgpass")
+	tmp, err := os.CreateTemp("", "pgpass")
 	if err != nil {
 		return errors.Wrap(err, "failed to create option file")
 	}

--- a/drivers/sqlboiler-psql/driver/psql.go
+++ b/drivers/sqlboiler-psql/driver/psql.go
@@ -972,7 +972,6 @@ func (p PostgresDriver) Imports() (importers.Collection, error) {
 				`"database/sql"`,
 				`"fmt"`,
 				`"io"`,
-				`"io/ioutil"`,
 				`"os"`,
 				`"os/exec"`,
 				`"regexp"`,

--- a/drivers/sqlboiler-psql/driver/psql_test.go
+++ b/drivers/sqlboiler-psql/driver/psql_test.go
@@ -34,7 +34,7 @@ var (
 )
 
 func TestAssemble(t *testing.T) {
-	b, err := ioutil.ReadFile("testdatabase.sql")
+	b, err := os.ReadFile("testdatabase.sql")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -107,7 +107,7 @@ func TestAssemble(t *testing.T) {
 				return
 			}
 
-			want, err := ioutil.ReadFile(tt.goldenJson)
+			want, err := os.ReadFile(tt.goldenJson)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/drivers/sqlboiler-psql/driver/psql_test.go
+++ b/drivers/sqlboiler-psql/driver/psql_test.go
@@ -13,7 +13,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"testing"
@@ -100,7 +99,7 @@ func TestAssemble(t *testing.T) {
 			}
 
 			if *flagOverwriteGolden {
-				if err = ioutil.WriteFile(tt.goldenJson, got, 0664); err != nil {
+				if err = os.WriteFile(tt.goldenJson, got, 0664); err != nil {
 					t.Fatal(err)
 				}
 				t.Log("wrote:", string(got))

--- a/drivers/sqlboiler-sqlite3/driver/sqlite3_test.go
+++ b/drivers/sqlboiler-sqlite3/driver/sqlite3_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -72,7 +71,7 @@ func TestDriver(t *testing.T) {
 			}
 
 			if *flagOverwriteGolden {
-				if err = ioutil.WriteFile(tt.goldenJson, got, 0664); err != nil {
+				if err = os.WriteFile(tt.goldenJson, got, 0664); err != nil {
 					t.Fatal(err)
 				}
 				t.Log("wrote:", string(got))

--- a/drivers/sqlboiler-sqlite3/driver/sqlite3_test.go
+++ b/drivers/sqlboiler-sqlite3/driver/sqlite3_test.go
@@ -24,7 +24,7 @@ var (
 
 func TestDriver(t *testing.T) {
 	rand.Seed(time.Now().Unix())
-	b, err := ioutil.ReadFile("testdatabase.sql")
+	b, err := os.ReadFile("testdatabase.sql")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +79,7 @@ func TestDriver(t *testing.T) {
 				return
 			}
 
-			want, err := ioutil.ReadFile(tt.goldenJson)
+			want, err := os.ReadFile(tt.goldenJson)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/importers/imports.go
+++ b/importers/imports.go
@@ -267,7 +267,6 @@ func NewDefaultImports() Collection {
 				`"bytes"`,
 				`"fmt"`,
 				`"io"`,
-				`"io/ioutil"`,
 				`"math/rand"`,
 				`"regexp"`,
 			},

--- a/queries/query_builders_test.go
+++ b/queries/query_builders_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -139,7 +138,7 @@ func TestBuildQuery(t *testing.T) {
 		out, args := BuildQuery(test.q)
 
 		if *writeGoldenFiles {
-			err := ioutil.WriteFile(filename, []byte(out), 0664)
+			err := os.WriteFile(filename, []byte(out), 0664)
 			if err != nil {
 				t.Fatalf("Failed to write golden file %s: %s\n", filename, err)
 			}

--- a/queries/query_builders_test.go
+++ b/queries/query_builders_test.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -146,7 +147,7 @@ func TestBuildQuery(t *testing.T) {
 			continue
 		}
 
-		byt, err := ioutil.ReadFile(filename)
+		byt, err := os.ReadFile(filename)
 		if err != nil {
 			t.Fatalf("Failed to read golden file %q: %v", filename, err)
 		}
@@ -516,11 +517,11 @@ func TestLimitClause(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		limit *int
+		limit           *int
 		expectPredicate func(sql string) bool
 	}{
 		{nil, func(sql string) bool {
-			return !strings.Contains(sql,"LIMIT")
+			return !strings.Contains(sql, "LIMIT")
 		}},
 		{newIntPtr(0), func(sql string) bool {
 			return strings.Contains(sql, "LIMIT 0")
@@ -532,7 +533,7 @@ func TestLimitClause(t *testing.T) {
 
 	for i, test := range tests {
 		q := &Query{
-			limit: test.limit,
+			limit:   test.limit,
 			dialect: &drivers.Dialect{LQ: '"', RQ: '"', UseIndexPlaceholders: true, UseTopClause: false},
 		}
 		sql, _ := BuildQuery(q)

--- a/templates/test/singleton/boil_queries_test.go.tpl
+++ b/templates/test/singleton/boil_queries_test.go.tpl
@@ -31,7 +31,7 @@ type fKeyDestroyer struct {
 
 func (f *fKeyDestroyer) Read(b []byte) (int, error) {
 	if f.buf == nil {
-		all, err := ioutil.ReadAll(f.reader)
+		all, err := io.ReadAll(f.reader)
 		if err != nil {
 			return 0, err
 		}


### PR DESCRIPTION
The io/ioutil package is deprecated since Go 1.16. https://go.dev/doc/go1.16#ioutil

I see sqlboiler is using Go 1.16 (https://github.com/volatiletech/sqlboiler/blob/master/go.mod#L3), so I've went ahead and replaced the old methods exported by `io/ioutil` to the corresponding methods moved to `io` and `os` packages.

As in the documentation, below is the list of old to new names, so for each commit I replaced the functions. In my final commit I removed the `io/ioutil` import which ended up not being needed anymore.

> [Discard](https://go.dev/pkg/io/ioutil/#Discard) => [io.Discard](https://go.dev/pkg/io/#Discard)
[NopCloser](https://go.dev/pkg/io/ioutil/#NopCloser) => [io.NopCloser](https://go.dev/pkg/io/#NopCloser)
[ReadAll](https://go.dev/pkg/io/ioutil/#ReadAll) => [io.ReadAll](https://go.dev/pkg/io/#ReadAll)
[ReadDir](https://go.dev/pkg/io/ioutil/#ReadDir) => [os.ReadDir](https://go.dev/pkg/os/#ReadDir) (note: returns a slice of [os.DirEntry](https://go.dev/pkg/os/#DirEntry) rather than a slice of [fs.FileInfo](https://go.dev/pkg/io/fs/#FileInfo))
[ReadFile](https://go.dev/pkg/io/ioutil/#ReadFile) => [os.ReadFile](https://go.dev/pkg/os/#ReadFile)
[TempDir](https://go.dev/pkg/io/ioutil/#TempDir) => [os.MkdirTemp](https://go.dev/pkg/os/#MkdirTemp)
[TempFile](https://go.dev/pkg/io/ioutil/#TempFile) => [os.CreateTemp](https://go.dev/pkg/os/#CreateTemp)
[WriteFile](https://go.dev/pkg/io/ioutil/#WriteFile) => [os.WriteFile](https://go.dev/pkg/os/#WriteFile)