### PR TITLE
Prepend schema to generated TableNames values

### DIFF
--- a/templates/main/singleton/boil_table_names.go.tpl
+++ b/templates/main/singleton/boil_table_names.go.tpl
@@ -4,6 +4,6 @@ var TableNames = struct {
 	{{end}}{{end -}}
 }{
 	{{range $table := .Tables}}{{if not $table.IsView -}}
-	{{titleCase $table.Name}}: "{{$table.Name}}",
+	{{titleCase $table.Name}}: "{{$table.Name | $.SchemaTable}}",
 	{{end}}{{end -}}
 }


### PR DESCRIPTION
The absence of the schema name prefix can lead to ambiguity and unexpected results if relying on default schema or search path behaviour of the target db. 