### PR TITLE
Fix composite key handling in sqlite3 driver

### DIFF
--- a/drivers/sqlboiler-sqlite3/driver/sqlite3.go
+++ b/drivers/sqlboiler-sqlite3/driver/sqlite3.go
@@ -349,7 +349,7 @@ func (s SQLiteDriver) Columns(schema, tableName string, whitelist, blacklist []s
 
 	nPkeys := 0
 	for _, column := range tinfo {
-		if column.Pk == 1 {
+		if column.Pk != 0 {
 			nPkeys++
 		}
 	}

--- a/drivers/sqlboiler-sqlite3/driver/sqlite3.golden.json
+++ b/drivers/sqlboiler-sqlite3/driver/sqlite3.golden.json
@@ -89,6 +89,58 @@
 			}
 		},
 		{
+			"name": "compositeprimarykeytest",
+			"schema_name": "",
+			"columns": [
+				{
+					"name": "a",
+					"type": "null.Int64",
+					"db_type": "INTEGER",
+					"default": "NULL",
+					"comment": "",
+					"nullable": true,
+					"unique": false,
+					"validated": false,
+					"auto_generated": false,
+					"arr_type": null,
+					"udt_name": "",
+					"domain_name": null,
+					"full_db_type": "INTEGER"
+				},
+				{
+					"name": "b",
+					"type": "null.Int64",
+					"db_type": "INTEGER",
+					"default": "NULL",
+					"comment": "",
+					"nullable": true,
+					"unique": false,
+					"validated": false,
+					"auto_generated": false,
+					"arr_type": null,
+					"udt_name": "",
+					"domain_name": null,
+					"full_db_type": "INTEGER"
+				}
+			],
+			"p_key": {
+				"name": "",
+				"columns": [
+					"a",
+					"b"
+				]
+			},
+			"f_keys": null,
+			"is_join_table": false,
+			"to_one_relationships": null,
+			"to_many_relationships": null,
+			"is_view": false,
+			"view_capabilities": {
+				"can_insert": false,
+				"can_upsert": false
+			}
+		},
+		{
 			"name": "has_generated_columns",
 			"schema_name": "",
 			"columns": [

--- a/drivers/sqlboiler-sqlite3/driver/testdatabase.sql
+++ b/drivers/sqlboiler-sqlite3/driver/testdatabase.sql
@@ -171,6 +171,15 @@ create table autoinckeywordtest (
 	b INTEGER
 );
 
+-- An INTEGER primary key column is an alias for the table rowid only if it is
+-- the only primary key column for the table. i.e. composite primary keys do
+-- not exhibit the rowid alias behaviour.
+create table compositeprimarykeytest (
+	a INTEGER,
+	b INTEGER,
+	PRIMARY KEY (a, b)
+);
+
 create view user_videos as 
 select u.id user_id, v.id video_id, v.sponsor_id sponsor_id
 from users u


### PR DESCRIPTION
Correctly count the number of primary key columns in SQLite tables so that INTEGER type columns within composite primary keys are not configured as auto_generated=true, default=auto_increment by sqlboiler.

The "PRAGMA table_xinfo" pk column is 0 for columns not part of the primary key, or the 1-based index of the column within the primary key. By checking if pk==1, only one primary key column is found, even for tables with a composite primary key. Instead check if pk is non-zero to detect all primary key columns.