### PR TITLE
Skipping empty values from the update list

### DIFF
--- a/drivers/sqlboiler-psql/driver/override/main/singleton/psql_upsert.go.tpl
+++ b/drivers/sqlboiler-psql/driver/override/main/singleton/psql_upsert.go.tpl
@@ -29,6 +29,9 @@ func buildUpsertQueryPostgres(dia drivers.Dialect, tableName string, updateOnCon
 		buf.WriteString(") DO UPDATE SET ")
 
 		for i, v := range update {
+		    if len(v) == 0 {
+		        continue
+		    }
 			if i != 0 {
 				buf.WriteByte(',')
 			}


### PR DESCRIPTION
I brought this up already in the [sqlboiler slack](https://sqlboiler.slack.com/archives/C3VDH4BU1/p1676663354729079), but wanted to just create this PR in parallel to waiting on a response.

I was running into an issue with the upsert query that’s being generated from an upsert operation i’m trying to perform (Postgres driver).

It’s generating invalid SQL (pq layer errors with a syntax error). I debugged all the way down to the psql_upsert.go file. It looks like when we’re ranging through the update column names that come in to the function, it doesn’t properly handle empty values. For some reason in my case, it’s passing in all the columns I want to update with 1 empty string at the end of the slice and this code generates invalid SQL.

A substring of the SQL that has the syntax error looks something like this:
```
"annualized_salary" = EXCLUDED."annualized_salary", = EXCLUDED. RETURNING "id"
```

When the empty string is present in the update column slice, that last update value is empty.