### PR TITLE
Fix qm.WithDeleted helper with a custom soft delete column

### DIFF
--- a/importers/imports.go
+++ b/importers/imports.go
@@ -212,6 +212,9 @@ func NewDefaultImports() Collection {
 
 	col.Singleton = Map{
 		"boil_queries": {
+			Standard: List{
+				`"regexp"`,
+			},
 			ThirdParty: List{
 				`"github.com/volatiletech/sqlboiler/v4/drivers"`,
 				`"github.com/volatiletech/sqlboiler/v4/queries"`,

--- a/queries/query.go
+++ b/queries/query.go
@@ -408,7 +408,13 @@ func RemoveSoftDeleteWhere(q *Query) {
 	q.removeSoftDelete = true
 }
 
-var deletedAtRgx = regexp.MustCompile("deleted_at[\"'`]? is null")
+var removeSoftDeleteRgx = regexp.MustCompile("deleted_at[\"'`]? is null")
+
+// SetRemoveSoftDeleteRgx sets the removeSoftDeleteRgx variable to support
+// qm.Where method to work with a custom soft delete auto-column name.
+func SetRemoveSoftDeleteRgx(rgx *regexp.Regexp) {
+	removeSoftDeleteRgx = rgx
+}
 
 // removeSoftDeleteWhere attempts to remove the soft delete where clause
 // added automatically by sqlboiler.
@@ -419,7 +425,7 @@ func (q *Query) removeSoftDeleteWhere() {
 
 	for i := len(q.where) - 1; i >= 0; i-- {
 		w := q.where[i]
-		if w.kind != whereKindNormal || !deletedAtRgx.MatchString(w.clause) {
+		if w.kind != whereKindNormal || !removeSoftDeleteRgx.MatchString(w.clause) {
 			continue
 		}
 

--- a/templates/main/singleton/boil_queries.go.tpl
+++ b/templates/main/singleton/boil_queries.go.tpl
@@ -12,6 +12,17 @@ var dialect = drivers.Dialect{
 	UseCaseWhenExistsClause: {{.Dialect.UseCaseWhenExistsClause}},
 }
 
+{{- if not .AutoColumns.Deleted }}
+    // This is a dummy variable to prevent unused regexp import error
+    var _ = &regexp.Regexp{}
+{{- end }}
+
+{{- if and (.AutoColumns.Deleted) (ne $.AutoColumns.Deleted "deleted_at") }}
+    func init() {
+        queries.SetRemoveSoftDeleteRgx(regexp.MustCompile("{{$.AutoColumns.Deleted}}[\"'`]? is null"))
+    }
+{{- end }}
+
 // NewQuery initializes a new Query using the passed in QueryMods
 func NewQuery(mods ...qm.QueryMod) *queries.Query {
 	q := &queries.Query{}


### PR DESCRIPTION
As the `deletedAtRgx` was hardcoded, there wasn't way to use the `qm.WithDeleted` helper when you have a custom soft delete column set in `auto-columns.deleted` config.

This PR fixes that, overwriting the variable when the the custom column is set and the soft deletion capatibilies are activated for that table.

Closes #1256