### PR TITLE
Add Inline query + args print

### DIFF
--- a/boil/debug.go
+++ b/boil/debug.go
@@ -58,9 +58,9 @@ func PrintQuery(writer io.Writer, query string, args ...interface{}) {
 	fmt.Fprintln(writer, substitutedQuery)
 }
 
-// substituteQueryArgs takes a SQL query string and an array of
-// // arguments. It returns a modified query string with placeholders replaced by their
-// // corresponding argument values.
+// substituteQueryArgs takes a query string and an array of arguments.
+// It returns a modified query string with placeholders replaced by their
+// corresponding argument values.
 func substituteQueryArgs(query string, args ...interface{}) string {
 	// find all occurrences of placeholders ($1, $2, etc.) in the query
 	re := regexp.MustCompile(`\$\d+`)

--- a/boil/debug.go
+++ b/boil/debug.go
@@ -2,8 +2,11 @@ package boil
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
+	"regexp"
+	"strings"
 )
 
 // DebugMode is a flag controlling whether generated sql statements and
@@ -46,4 +49,39 @@ func DebugWriterFrom(ctx context.Context) io.Writer {
 		return writer
 	}
 	return DebugWriter
+}
+
+// PrintQuery prints a modified query string with placeholders replaced by their
+// corresponding argument values to writer.
+func PrintQuery(writer io.Writer, query string, args ...interface{}) {
+	substitutedQuery := substituteQueryArgs(query, args...)
+	fmt.Fprintln(writer, substitutedQuery)
+}
+
+// substituteQueryArgs takes a SQL query string and an array of
+// // arguments. It returns a modified query string with placeholders replaced by their
+// // corresponding argument values.
+func substituteQueryArgs(query string, args ...interface{}) string {
+	// find all occurrences of placeholders ($1, $2, etc.) in the query
+	re := regexp.MustCompile(`\$\d+`)
+	matches := re.FindAllString(query, -1)
+
+	for i, match := range matches {
+		var arg string
+
+		switch v := args[i].(type) {
+		case string:
+			arg = fmt.Sprintf("'%s'", v)
+		case []byte:
+			arg = fmt.Sprintf("'%s'", string(v))
+		default:
+			arg = fmt.Sprintf("%v", v)
+		}
+
+		// replace the placeholder with the argument value
+		query = strings.Replace(query, match, arg, 1)
+	}
+
+	// return the final query with argument values
+	return query
 }

--- a/boil/debug_test.go
+++ b/boil/debug_test.go
@@ -1,0 +1,57 @@
+package boil
+
+import (
+	"testing"
+)
+
+func TestSubstituteQueryArgs(t *testing.T) {
+	tests := []struct {
+		query string
+		args  []interface{}
+		want  string
+	}{
+		{
+			query: `INSERT INTO "my_table" ("id","name","age","height","is_active","data") VALUES ($1,$2,$3,$4,$5,$6)`,
+			args: []interface{}{
+				1, "Alice", 25, 1.68, true, []byte(`{"key":"value"}`),
+			},
+			want: `INSERT INTO "my_table" ("id","name","age","height","is_active","data") VALUES (1,'Alice',25,1.68,true,'{"key":"value"}')`,
+		},
+		{
+			query: `UPDATE "my_table" SET "name"=$1,"age"=$2,"height"=$3,"is_active"=$4,"data"=$5 WHERE "id"=$6`,
+			args: []interface{}{
+				"Bob", 30, 1.78, false, []byte(`{"key":123}`), 2,
+			},
+			want: `UPDATE "my_table" SET "name"='Bob',"age"=30,"height"=1.78,"is_active"=false,"data"='{"key":123}' WHERE "id"=2`,
+		},
+		{
+			query: `DELETE FROM "my_table" WHERE "id"=$1`,
+			args: []interface{}{
+				4,
+			},
+			want: `DELETE FROM "my_table" WHERE "id"=4`,
+		},
+		{
+			query: `SELECT * FROM "my_table"`,
+			args:  []interface{}{},
+			want:  `SELECT * FROM "my_table"`,
+		},
+		{
+			query: `UPDATE "my_table" SET "name"=$1,"age"=$2,"height"=$3,"is_active"=$4,"data"=$5 WHERE "id"=$6`,
+			args: []interface{}{
+				"Bob", 30, 1.78, false, []byte(`{"key":123}`), 2,
+			},
+			want: `UPDATE "my_table" SET "name"='Bob',"age"=30,"height"=1.78,"is_active"=false,"data"='{"key":123}' WHERE "id"=2`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.query, func(t *testing.T) {
+			got := substituteQueryArgs(tt.query, tt.args...)
+
+			if got != tt.want {
+				t.Errorf("substituteQueryArgs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/boil/debug_test.go
+++ b/boil/debug_test.go
@@ -18,20 +18,6 @@ func TestSubstituteQueryArgs(t *testing.T) {
 			want: `INSERT INTO "my_table" ("id","name","age","height","is_active","data") VALUES (1,'Alice',25,1.68,true,'{"key":"value"}')`,
 		},
 		{
-			query: `UPDATE "my_table" SET "name"=$1,"age"=$2,"height"=$3,"is_active"=$4,"data"=$5 WHERE "id"=$6`,
-			args: []interface{}{
-				"Bob", 30, 1.78, false, []byte(`{"key":123}`), 2,
-			},
-			want: `UPDATE "my_table" SET "name"='Bob',"age"=30,"height"=1.78,"is_active"=false,"data"='{"key":123}' WHERE "id"=2`,
-		},
-		{
-			query: `DELETE FROM "my_table" WHERE "id"=$1`,
-			args: []interface{}{
-				4,
-			},
-			want: `DELETE FROM "my_table" WHERE "id"=4`,
-		},
-		{
 			query: `SELECT * FROM "my_table"`,
 			args:  []interface{}{},
 			want:  `SELECT * FROM "my_table"`,

--- a/drivers/sqlboiler-mssql/driver/override/main/17_upsert.go.tpl
+++ b/drivers/sqlboiler-mssql/driver/override/main/17_upsert.go.tpl
@@ -130,14 +130,12 @@ func (o *{{$alias.UpSingular}}) Upsert({{if .NoContext}}exec boil.Executor{{else
 
 	{{if .NoContext -}}
 	if boil.DebugMode {
-		fmt.Fprintln(boil.DebugWriter, cache.query)
-		fmt.Fprintln(boil.DebugWriter, vals)
+		boil.PrintQuery(boil.DebugWriter, cache.query, vals...)
 	}
 	{{else -}}
 	if boil.IsDebug(ctx) {
 		writer := boil.DebugWriterFrom(ctx)
-		fmt.Fprintln(writer, cache.query)
-		fmt.Fprintln(writer, vals)
+		boil.PrintQuery(writer, cache.query, vals...)
 	}
 	{{end -}}
 

--- a/drivers/sqlboiler-mysql/driver/override/main/17_upsert.go.tpl
+++ b/drivers/sqlboiler-mysql/driver/override/main/17_upsert.go.tpl
@@ -138,14 +138,12 @@ func (o *{{$alias.UpSingular}}) Upsert({{if .NoContext}}exec boil.Executor{{else
 
 	{{if .NoContext -}}
 	if boil.DebugMode {
-		fmt.Fprintln(boil.DebugWriter, cache.query)
-		fmt.Fprintln(boil.DebugWriter, vals)
+		boil.PrintQuery(boil.DebugWriter, cache.query, vals...)
 	}
 	{{else -}}
 	if boil.IsDebug(ctx) {
 		writer := boil.DebugWriterFrom(ctx)
-		fmt.Fprintln(writer, cache.query)
-		fmt.Fprintln(writer, vals)
+		boil.PrintQuery(writer, cache.query, vals...)
 	}
 	{{end -}}
 
@@ -200,14 +198,12 @@ func (o *{{$alias.UpSingular}}) Upsert({{if .NoContext}}exec boil.Executor{{else
 
 	{{if .NoContext -}}
 	if boil.DebugMode {
-		fmt.Fprintln(boil.DebugWriter, cache.retQuery)
-		fmt.Fprintln(boil.DebugWriter, nzUniqueCols...)
+		boil.PrintQuery(boil.DebugWriter, cache.retQuery, nzUniqueCols...)
 	}
 	{{else -}}
 	if boil.IsDebug(ctx) {
 		writer := boil.DebugWriterFrom(ctx)
-		fmt.Fprintln(writer, cache.retQuery)
-		fmt.Fprintln(writer, nzUniqueCols...)
+		boil.PrintQuery(writer, cache.retQuery, nzUniqueCols...)
 	}
 	{{end -}}
 

--- a/drivers/sqlboiler-psql/driver/override/main/17_upsert.go.tpl
+++ b/drivers/sqlboiler-psql/driver/override/main/17_upsert.go.tpl
@@ -130,14 +130,12 @@ func (o *{{$alias.UpSingular}}) Upsert({{if .NoContext}}exec boil.Executor{{else
 
 	{{if .NoContext -}}
 	if boil.DebugMode {
-		fmt.Fprintln(boil.DebugWriter, cache.query)
-		fmt.Fprintln(boil.DebugWriter, vals)
+		boil.PrintQuery(boil.DebugWriter, cache.query, vals...)
 	}
 	{{else -}}
 	if boil.IsDebug(ctx) {
 		writer := boil.DebugWriterFrom(ctx)
-		fmt.Fprintln(writer, cache.query)
-		fmt.Fprintln(writer, vals)
+		boil.PrintQuery(writer, cache.query, vals...)
 	}
 	{{end -}}
 

--- a/drivers/sqlboiler-sqlite3/driver/override/main/17_upsert.go.tpl
+++ b/drivers/sqlboiler-sqlite3/driver/override/main/17_upsert.go.tpl
@@ -125,14 +125,12 @@ func (o *{{$alias.UpSingular}}) Upsert({{if .NoContext}}exec boil.Executor{{else
 
 	{{if .NoContext -}}
 	if boil.DebugMode {
-		fmt.Fprintln(boil.DebugWriter, cache.query)
-		fmt.Fprintln(boil.DebugWriter, vals)
+		boil.PrintQuery(boil.DebugWriter, cache.query, vals...)
 	}
 	{{else -}}
 	if boil.IsDebug(ctx) {
 		writer := boil.DebugWriterFrom(ctx)
-		fmt.Fprintln(writer, cache.query)
-		fmt.Fprintln(writer, vals)
+		boil.PrintQuery(writer, cache.query, vals...)
 	}
 	{{end -}}
 

--- a/queries/query.go
+++ b/queries/query.go
@@ -3,7 +3,6 @@ package queries
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"regexp"
 
 	"github.com/volatiletech/sqlboiler/v4/boil"
@@ -118,8 +117,7 @@ func RawG(query string, args ...interface{}) *Query {
 func (q *Query) Exec(exec boil.Executor) (sql.Result, error) {
 	qs, args := BuildQuery(q)
 	if boil.DebugMode {
-		fmt.Fprintln(boil.DebugWriter, qs)
-		fmt.Fprintln(boil.DebugWriter, args)
+		boil.PrintQuery(boil.DebugWriter, qs, args...)
 	}
 	return exec.Exec(qs, args...)
 }
@@ -128,8 +126,7 @@ func (q *Query) Exec(exec boil.Executor) (sql.Result, error) {
 func (q *Query) QueryRow(exec boil.Executor) *sql.Row {
 	qs, args := BuildQuery(q)
 	if boil.DebugMode {
-		fmt.Fprintln(boil.DebugWriter, qs)
-		fmt.Fprintln(boil.DebugWriter, args)
+		boil.PrintQuery(boil.DebugWriter, qs, args...)
 	}
 	return exec.QueryRow(qs, args...)
 }
@@ -138,8 +135,7 @@ func (q *Query) QueryRow(exec boil.Executor) *sql.Row {
 func (q *Query) Query(exec boil.Executor) (*sql.Rows, error) {
 	qs, args := BuildQuery(q)
 	if boil.DebugMode {
-		fmt.Fprintln(boil.DebugWriter, qs)
-		fmt.Fprintln(boil.DebugWriter, args)
+		boil.PrintQuery(boil.DebugWriter, qs, args...)
 	}
 	return exec.Query(qs, args...)
 }
@@ -149,8 +145,7 @@ func (q *Query) ExecContext(ctx context.Context, exec boil.ContextExecutor) (sql
 	qs, args := BuildQuery(q)
 	if boil.IsDebug(ctx) {
 		writer := boil.DebugWriterFrom(ctx)
-		fmt.Fprintln(writer, qs)
-		fmt.Fprintln(writer, args)
+		boil.PrintQuery(writer, qs, args...)
 	}
 	return exec.ExecContext(ctx, qs, args...)
 }
@@ -160,8 +155,7 @@ func (q *Query) QueryRowContext(ctx context.Context, exec boil.ContextExecutor) 
 	qs, args := BuildQuery(q)
 	if boil.IsDebug(ctx) {
 		writer := boil.DebugWriterFrom(ctx)
-		fmt.Fprintln(writer, qs)
-		fmt.Fprintln(writer, args)
+		boil.PrintQuery(writer, qs, args...)
 	}
 	return exec.QueryRowContext(ctx, qs, args...)
 }
@@ -171,8 +165,7 @@ func (q *Query) QueryContext(ctx context.Context, exec boil.ContextExecutor) (*s
 	qs, args := BuildQuery(q)
 	if boil.IsDebug(ctx) {
 		writer := boil.DebugWriterFrom(ctx)
-		fmt.Fprintln(writer, qs)
-		fmt.Fprintln(writer, args)
+		boil.PrintQuery(writer, qs, args...)
 	}
 	return exec.QueryContext(ctx, qs, args...)
 }


### PR DESCRIPTION
Attempt at https://github.com/volatiletech/sqlboiler/issues/499

It works well with non `Null` types but unfortunately `Null` types will always output their `valid` values like so:

```
"INSERT INTO \"rockets\" (\"id\",\"name\",\"model\",\"launched\",\"launch_date\",\"data\") VALUES ('1c309a44-c3b6-4924-b5b4-57532cff1c1f',{bunpollo 13 true},{1 true},{true true},{2023-04-10 02:59:16.207365677 +0000 UTC m=+9.860239922 true},{[123 34 100 97 116 97 34 58 34 116 101 115 116 34 125] true})"
``` 

From a personal standpoint, this is an improvement to current logging so I'm happy with this, but this might be a naive approach so any suggestions welcome.
