### PR TITLE
postgres Driver is missing types import on non nullable char column

### DIFF
--- a/drivers/sqlboiler-psql/driver/psql.go
+++ b/drivers/sqlboiler-psql/driver/psql.go
@@ -1048,6 +1048,9 @@ func (p PostgresDriver) Imports() (importers.Collection, error) {
 		"types.Decimal": {
 			ThirdParty: importers.List{`"github.com/volatiletech/sqlboiler/v4/types"`},
 		},
+		"types.Byte": {
+			ThirdParty: importers.List{`"github.com/volatiletech/sqlboiler/v4/types"`},
+		},
 		"types.BytesArray": {
 			ThirdParty: importers.List{`"github.com/volatiletech/sqlboiler/v4/types"`},
 		},


### PR DESCRIPTION
I am using Postgres v15.

The generation of my Database Models fails.

With a simple Scheme such as:
```sql
CREATE TABLE IF NOT EXISTS public.history
(
    id uuid NOT NULL DEFAULT uuid_generate_v4(),
    ts timestamp with time zone NOT NULL,
    state  "char" NOT NULL DEFAULT (0)::"char",
    CONSTRAINT history_pkey PRIMARY KEY (id)
)
```
the PSQL Driver won't add the Types import to the Import Map.

Please add this Type Based Import to the Driver.
