### PR TITLE
add string pattern matching to templates

### DIFF
--- a/drivers/sqlboiler-psql/driver/override/main/22_ilike.go.tpl
+++ b/drivers/sqlboiler-psql/driver/override/main/22_ilike.go.tpl
@@ -1,0 +1,5 @@
+{{- define "where_ilike_override" -}}
+    {{$name := printf "whereHelper%s" (goVarname .Type)}}
+func (w {{$name}}) ILIKE(x {{.Type}}) qm.QueryMod { return qm.Where(w.field+" ILIKE ?", x) }
+func (w {{$name}}) NILIKE(x {{.Type}}) qm.QueryMod { return qm.Where(w.field+" NOT ILIKE ?", x) }
+{{- end -}}

--- a/templates/main/00_struct.go.tpl
+++ b/templates/main/00_struct.go.tpl
@@ -63,6 +63,11 @@ func (w {{$name}}) LT(x {{.Type}}) qm.QueryMod { return qmhelper.Where(w.field, 
 func (w {{$name}}) LTE(x {{.Type}}) qm.QueryMod { return qmhelper.Where(w.field, qmhelper.LTE, x) }
 func (w {{$name}}) GT(x {{.Type}}) qm.QueryMod { return qmhelper.Where(w.field, qmhelper.GT, x) }
 func (w {{$name}}) GTE(x {{.Type}}) qm.QueryMod { return qmhelper.Where(w.field, qmhelper.GTE, x) }
+		{{if or (eq .Type "string") (eq .Type "null.String") -}}
+func (w {{$name}}) LIKE(x {{.Type}}) qm.QueryMod { return qm.Where(w.field+" LIKE ?", x) }
+func (w {{$name}}) NLIKE(x {{.Type}}) qm.QueryMod { return qm.Where(w.field+" NOT LIKE ?", x) }
+			{{- template "where_ilike_override" . }}
+		{{end -}}
 		{{if or (isPrimitive .Type) (isNullPrimitive .Type) (isEnumDBType .DBType) -}}
 func (w {{$name}}) IN(slice []{{convertNullToPrimitive .Type}}) qm.QueryMod {
 	values := make([]interface{}, 0, len(slice))

--- a/templates/main/00_struct.go.tpl
+++ b/templates/main/00_struct.go.tpl
@@ -66,7 +66,7 @@ func (w {{$name}}) GTE(x {{.Type}}) qm.QueryMod { return qmhelper.Where(w.field,
 		{{if or (eq .Type "string") (eq .Type "null.String") -}}
 func (w {{$name}}) LIKE(x {{.Type}}) qm.QueryMod { return qm.Where(w.field+" LIKE ?", x) }
 func (w {{$name}}) NLIKE(x {{.Type}}) qm.QueryMod { return qm.Where(w.field+" NOT LIKE ?", x) }
-			{{- template "where_ilike_override" . }}
+			{{- block "where_ilike_override" . }}{{- end}}
 		{{end -}}
 		{{if or (isPrimitive .Type) (isNullPrimitive .Type) (isEnumDBType .DBType) -}}
 func (w {{$name}}) IN(slice []{{convertNullToPrimitive .Type}}) qm.QueryMod {


### PR DESCRIPTION
Based on issue [Add LIKE and ILIKE Operators #1218](https://github.com/volatiletech/sqlboiler/issues/1218)

There was discussion in the issue that this should not be added to `qmhelper` so I just used `qm.Where`. If there are no technical reasons to not extend `qmhelper` I think adding at least the shared operators there would fit nicely. I ended up extending the base templates with the `LIKE` and `NOT LIKE` operators because those should be shared between all the supported dialects. Since postgres is the only one that supports `ILIKE`, I added that as an override. I tried to think over how to add tests to these but did not come up with anything so far.

Tested the resulting models with postgres, could use with more dialects being manually tested

p.s. this is my first contribution to open source so all feedback is very appreciated