### PR TITLE
Allow define foreign key relationships in config file

### DIFF
--- a/boilingcore/config.go
+++ b/boilingcore/config.go
@@ -48,10 +48,11 @@ type Config struct {
 	DefaultTemplates    fs.FS            `toml:"-" json:"-"`
 	CustomTemplateFuncs template.FuncMap `toml:"-" json:"-"`
 
-	Aliases      Aliases       `toml:"aliases,omitempty" json:"aliases,omitempty"`
-	TypeReplaces []TypeReplace `toml:"type_replaces,omitempty" json:"type_replaces,omitempty"`
-	AutoColumns  AutoColumns   `toml:"auto_columns,omitempty" json:"auto_columns,omitempty"`
-	Inflections  Inflections   `toml:"inflections,omitempty" json:"inflections,omitempty"`
+	Aliases      Aliases              `toml:"aliases,omitempty" json:"aliases,omitempty"`
+	TypeReplaces []TypeReplace        `toml:"type_replaces,omitempty" json:"type_replaces,omitempty"`
+	AutoColumns  AutoColumns          `toml:"auto_columns,omitempty" json:"auto_columns,omitempty"`
+	Inflections  Inflections          `toml:"inflections,omitempty" json:"inflections,omitempty"`
+	ForeignKeys  []drivers.ForeignKey `toml:"foreign_keys,omitempty" json:"foreign_keys,omitempty" `
 
 	Version string `toml:"version" json:"version"`
 }

--- a/boilingcore/config.go
+++ b/boilingcore/config.go
@@ -1,11 +1,13 @@
 package boilingcore
 
 import (
+	"fmt"
 	"io/fs"
 	"path/filepath"
 	"strings"
 	"text/template"
 
+	"github.com/friendsofgo/errors"
 	"github.com/spf13/cast"
 
 	"github.com/volatiletech/sqlboiler/v4/drivers"
@@ -91,27 +93,27 @@ func (c *Config) OutputDirDepth() int {
 //
 // It also supports two different syntaxes, because of viper:
 //
-//   [aliases.tables.table_name]
-//   fields... = "values"
-//     [aliases.tables.columns]
-//     colname = "alias"
-//     [aliases.tables.relationships.fkey_name]
-//     local   = "x"
-//     foreign = "y"
+//	[aliases.tables.table_name]
+//	fields... = "values"
+//	  [aliases.tables.columns]
+//	  colname = "alias"
+//	  [aliases.tables.relationships.fkey_name]
+//	  local   = "x"
+//	  foreign = "y"
 //
 // Or alternatively (when toml key names or viper's
 // lowercasing of key names gets in the way):
 //
-//   [[aliases.tables]]
-//   name = "table_name"
-//   fields... = "values"
-//     [[aliases.tables.columns]]
-//     name  = "colname"
-//     alias = "alias"
-//     [[aliases.tables.relationships]]
-//     name    = "fkey_name"
-//     local   = "x"
-//     foreign = "y"
+//	[[aliases.tables]]
+//	name = "table_name"
+//	fields... = "values"
+//	  [[aliases.tables.columns]]
+//	  name  = "colname"
+//	  alias = "alias"
+//	  [[aliases.tables.relationships]]
+//	  name    = "fkey_name"
+//	  local   = "x"
+//	  foreign = "y"
 func ConvertAliases(i interface{}) (a Aliases) {
 	if i == nil {
 		return a
@@ -282,4 +284,82 @@ func columnFromInterface(i interface{}) (col drivers.Column) {
 	}
 
 	return col
+}
+
+// ConvertForeignKeys is necessary because viper
+//
+// It also supports two different syntaxes, because of viper:
+//
+//	[foreign_keys.fk_1]
+//	table = "table_name"
+//	column = "column_name"
+//	foreign_table = "foreign_table_name"
+//	foreign_column = "foreign_column_name"
+//
+// Or alternatively (when toml key names or viper's
+// lowercasing of key names gets in the way):
+//
+//	[[foreign_keys]]
+//	name = "fk_1"
+//	table = "table_name"
+//	column = "column_name"
+//	foreign_table = "foreign_table_name"
+//	foreign_column = "foreign_column_name"
+func ConvertForeignKeys(i interface{}) (fks []drivers.ForeignKey) {
+	if i == nil {
+		return nil
+	}
+
+	iterateMapOrSlice(i, func(name string, obj interface{}) {
+		t := cast.ToStringMap(obj)
+
+		fk := drivers.ForeignKey{
+			Table:         cast.ToString(t["table"]),
+			Name:          name,
+			Column:        cast.ToString(t["column"]),
+			ForeignTable:  cast.ToString(t["foreign_table"]),
+			ForeignColumn: cast.ToString(t["foreign_column"]),
+		}
+		if err := validateForeignKey(fk); err != nil {
+			panic(errors.Errorf("invalid foreign key %s: %s", name, err))
+		}
+		fks = append(fks, fk)
+	})
+
+	if err := validateDuplicateForeignKeys(fks); err != nil {
+		panic(errors.Errorf("invalid foreign keys: %s", err))
+	}
+
+	return fks
+}
+
+func validateForeignKey(fk drivers.ForeignKey) error {
+	if fk.Name == "" {
+		return errors.New("foreign key must have a name")
+	}
+	if fk.Table == "" {
+		return errors.New("foreign key must have a table")
+	}
+	if fk.Column == "" {
+		return errors.New("foreign key must have a column")
+	}
+	if fk.ForeignTable == "" {
+		return errors.New("foreign key must have a foreign table")
+	}
+	if fk.ForeignColumn == "" {
+		return errors.New("foreign key must have a foreign column")
+	}
+	return nil
+}
+
+func validateDuplicateForeignKeys(fks []drivers.ForeignKey) error {
+	fkMap := make(map[string]drivers.ForeignKey)
+	for _, fk := range fks {
+		key := fmt.Sprintf("%s.%s", fk.Table, fk.Column)
+		if _, ok := fkMap[key]; ok {
+			return errors.Errorf("duplicate foreign key name: %s", fk.Name)
+		}
+		fkMap[key] = fk
+	}
+	return nil
 }

--- a/boilingcore/config_test.go
+++ b/boilingcore/config_test.go
@@ -254,3 +254,66 @@ func TestConvertTypeReplace(t *testing.T) {
 		t.Error("tables in types.match wrong:", got)
 	}
 }
+
+func TestConvertForeignKeys(t *testing.T) {
+	t.Parallel()
+
+	var intf interface{} = map[string]interface{}{
+		"fk_1": map[string]interface{}{
+			"table":          "table_name",
+			"column":         "column_name",
+			"foreign_table":  "foreign_table_name",
+			"foreign_column": "foreign_column_name",
+		},
+	}
+
+	fks := ConvertForeignKeys(intf)
+	if len(fks) != 1 {
+		t.Error("should have one entry")
+	}
+
+	fk := fks[0]
+	expectedFK := drivers.ForeignKey{
+		Name:          "fk_1",
+		Table:         "table_name",
+		Column:        "column_name",
+		ForeignTable:  "foreign_table_name",
+		ForeignColumn: "foreign_column_name",
+	}
+
+	if fk != expectedFK {
+		t.Error("value was wrong:", fk)
+	}
+}
+
+func TestConvertForeignKeysAltSyntax(t *testing.T) {
+	t.Parallel()
+
+	var intf interface{} = []interface{}{
+		map[string]interface{}{
+			"name":           "fk_1",
+			"table":          "table_name",
+			"column":         "column_name",
+			"foreign_table":  "foreign_table_name",
+			"foreign_column": "foreign_column_name",
+		},
+	}
+
+	fks := ConvertForeignKeys(intf)
+	if len(fks) != 1 {
+		t.Error("should have one entry")
+	}
+
+	fk := fks[0]
+	expectedFK := drivers.ForeignKey{
+		Name:          "fk_1",
+		Table:         "table_name",
+		Column:        "column_name",
+		ForeignTable:  "foreign_table_name",
+		ForeignColumn: "foreign_column_name",
+	}
+
+	if fk != expectedFK {
+		t.Error("value was wrong:", fk)
+	}
+}

--- a/drivers/config_test.go
+++ b/drivers/config_test.go
@@ -274,3 +274,174 @@ func TestColumnsFromList(t *testing.T) {
 		t.Error("list was wrong:", got)
 	}
 }
+
+func TestConfig_MustForeignKeys(t *testing.T) {
+	tests := []struct {
+		name  string
+		c     Config
+		want  []ForeignKey
+		panic bool
+	}{
+		{
+			name:  "no foreign keys",
+			c:     Config{},
+			want:  nil,
+			panic: false,
+		},
+		{
+			name: "nil foreign keys",
+			c: Config{
+				"foreign-keys": nil,
+			},
+			want:  nil,
+			panic: false,
+		},
+		{
+			name: "have foreign keys",
+			c: Config{
+				"foreign-keys": []ForeignKey{
+					{
+						Name:          "test_fk",
+						Table:         "table_name",
+						Column:        "column_name",
+						ForeignColumn: "foreign_column_name",
+						ForeignTable:  "foreign_table_name",
+					},
+				},
+			},
+			want: []ForeignKey{
+				{
+					Name:          "test_fk",
+					Table:         "table_name",
+					Column:        "column_name",
+					ForeignColumn: "foreign_column_name",
+					ForeignTable:  "foreign_table_name",
+				},
+			},
+			panic: false,
+		},
+		{
+			name: "invalid foreign keys",
+			c: Config{
+				"foreign-keys": 1,
+			},
+			panic: true,
+		},
+		{
+			name: "foreign keys in []interface{} format",
+			c: Config{
+				"foreign-keys": []interface{}{
+					map[string]interface{}{
+						"name":           "test_fk",
+						"table":          "table_name",
+						"column":         "column_name",
+						"foreign_column": "foreign_column_name",
+						"foreign_table":  "foreign_table_name",
+					},
+				},
+			},
+			want: []ForeignKey{
+				{
+					Name:          "test_fk",
+					Table:         "table_name",
+					Column:        "column_name",
+					ForeignColumn: "foreign_column_name",
+					ForeignTable:  "foreign_table_name",
+				},
+			},
+			panic: false,
+		},
+		{
+			name: "invalid foreign keys in []interface{} format",
+			c: Config{
+				"foreign-keys": []interface{}{
+					"123",
+				},
+			},
+			panic: true,
+		},
+		{
+			name: "foreign keys in []map[string]string format but missing fields",
+			c: Config{
+				"foreign-keys": []interface{}{
+					map[string]interface{}{
+						"name": "test_fk",
+					},
+				},
+			},
+			want:  nil,
+			panic: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got []ForeignKey
+			var paniced interface{}
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						paniced = r
+					}
+				}()
+				got = tt.c.MustForeignKeys(ConfigForeignKeys)
+			}()
+
+			if tt.panic && paniced == nil {
+				t.Errorf("MustForeignKeys() should have panicked")
+			}
+			if !tt.panic && paniced != nil {
+				t.Errorf("MustForeignKeys() should not have panicked")
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("MustForeignKeys() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCombineConfigAndDBForeignKeys(t *testing.T) {
+	configForeignKeys := []ForeignKey{
+		{
+			Name:          "config_fk1",
+			Table:         "table_A",
+			Column:        "column_A1",
+			ForeignColumn: "column_B1",
+			ForeignTable:  "table_B",
+		},
+		{
+			Name:          "config_fk2",
+			Table:         "table_C",
+			Column:        "column_C1",
+			ForeignColumn: "column_B1",
+			ForeignTable:  "table_B",
+		},
+		{
+			Name:          "config_fk3",
+			Table:         "table_A",
+			Column:        "column_A2",
+			ForeignColumn: "column_D2",
+			ForeignTable:  "table_D",
+		},
+	}
+	tableName := "table_A"
+	dbForeignKeys := []ForeignKey{
+		{
+			Name:          "db_fk1",
+			Table:         "table_A",
+			Column:        "column_A1",
+			ForeignColumn: "column_E1",
+			ForeignTable:  "table_E",
+		},
+	}
+
+	expected := []ForeignKey{
+		configForeignKeys[0],
+		configForeignKeys[2],
+	}
+
+	got := CombineConfigAndDBForeignKeys(configForeignKeys, tableName, dbForeignKeys)
+
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("CombineConfigAndDBForeignKeys() = %v, want %v", got, expected)
+	}
+}

--- a/drivers/interface.go
+++ b/drivers/interface.go
@@ -7,8 +7,9 @@ import (
 	"sync"
 
 	"github.com/friendsofgo/errors"
-	"github.com/volatiletech/sqlboiler/v4/importers"
 	"github.com/volatiletech/strmangle"
+
+	"github.com/volatiletech/sqlboiler/v4/importers"
 )
 
 // These constants are used in the config map passed into the driver
@@ -19,6 +20,7 @@ const (
 	ConfigAddEnumTypes   = "add-enum-types"
 	ConfigEnumNullPrefix = "enum-null-prefix"
 	ConfigConcurrency    = "concurrency"
+	ConfigForeignKeys    = "foreign-keys"
 
 	ConfigUser    = "user"
 	ConfigPass    = "pass"

--- a/drivers/sqlboiler-mysql/driver/mysql.go
+++ b/drivers/sqlboiler-mysql/driver/mysql.go
@@ -11,9 +11,10 @@ import (
 
 	"github.com/friendsofgo/errors"
 	"github.com/go-sql-driver/mysql"
+	"github.com/volatiletech/strmangle"
+
 	"github.com/volatiletech/sqlboiler/v4/drivers"
 	"github.com/volatiletech/sqlboiler/v4/importers"
-	"github.com/volatiletech/strmangle"
 )
 
 //go:embed override
@@ -33,11 +34,12 @@ func Assemble(config drivers.Config) (dbinfo *drivers.DBInfo, err error) {
 // MySQLDriver holds the database connection string and a handle
 // to the database connection.
 type MySQLDriver struct {
-	connStr        string
-	conn           *sql.DB
-	addEnumTypes   bool
-	enumNullPrefix string
-	tinyIntAsInt   bool
+	connStr           string
+	conn              *sql.DB
+	addEnumTypes      bool
+	enumNullPrefix    string
+	tinyIntAsInt      bool
+	configForeignKeys []drivers.ForeignKey
 }
 
 // Templates that should be added/overridden
@@ -95,6 +97,7 @@ func (m *MySQLDriver) Assemble(config drivers.Config) (dbinfo *drivers.DBInfo, e
 	m.addEnumTypes, _ = config[drivers.ConfigAddEnumTypes].(bool)
 	m.enumNullPrefix = strmangle.TitleCase(config.DefaultString(drivers.ConfigEnumNullPrefix, "Null"))
 	m.connStr = MySQLBuildQueryString(user, pass, dbname, host, port, sslmode)
+	m.configForeignKeys = config.MustForeignKeys(drivers.ConfigForeignKeys)
 	m.conn, err = sql.Open("mysql", m.connStr)
 	if err != nil {
 		return nil, errors.Wrap(err, "sqlboiler-mysql failed to connect to database")
@@ -405,6 +408,14 @@ func (m *MySQLDriver) PrimaryKeyInfo(schema, tableName string) (*drivers.Primary
 
 // ForeignKeyInfo retrieves the foreign keys for a given table name.
 func (m *MySQLDriver) ForeignKeyInfo(schema, tableName string) ([]drivers.ForeignKey, error) {
+	dbForeignKeys, err := m.foreignKeyInfoFromDB(schema, tableName)
+	if err != nil {
+		return nil, errors.Wrap(err, "read foreign keys info from db")
+	}
+
+	return drivers.CombineConfigAndDBForeignKeys(m.configForeignKeys, tableName, dbForeignKeys), nil
+}
+func (m *MySQLDriver) foreignKeyInfoFromDB(schema, tableName string) ([]drivers.ForeignKey, error) {
 	var fkeys []drivers.ForeignKey
 
 	query := `

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/friendsofgo/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
 	"github.com/volatiletech/sqlboiler/v4/boilingcore"
 	"github.com/volatiletech/sqlboiler/v4/drivers"
 	"github.com/volatiletech/sqlboiler/v4/importers"
@@ -190,6 +191,7 @@ func preRun(cmd *cobra.Command, args []string) error {
 			SingularExact: viper.GetStringMapString("inflections.singular_exact"),
 			Irregular:     viper.GetStringMapString("inflections.irregular"),
 		},
+		ForeignKeys: boilingcore.ConvertForeignKeys(viper.Get("foreign_keys")),
 
 		Version: sqlBoilerVersion,
 	}
@@ -204,6 +206,7 @@ func preRun(cmd *cobra.Command, args []string) error {
 		"blacklist":        viper.GetStringSlice(driverName + ".blacklist"),
 		"add-enum-types":   cmdConfig.AddEnumTypes,
 		"enum-null-prefix": cmdConfig.EnumNullPrefix,
+		"foreign-keys":     cmdConfig.ForeignKeys,
 	}
 
 	keys := allKeys(driverName)


### PR DESCRIPTION
## What?
I've added support for define relationships in config file. This would allow you to use sqlboiler with platform that does not support foreign keys.
For more background, see #1163 

## Proposal configs
Here is an example config will be added to config file.
```toml
#...
[foreign_keys.jet_pilots_fkey]
table = "jets"
column = "pilot_id"
foreign_table = "pilots"
foreign_column = "id"

[foreign_keys.pilot_language_pilots_fkey]
table = "pilot_languages"
column = "pilot_id"
foreign_table = "pilots"
foreign_column = "id"

[foreign_keys.pilot_language_languages_fkey]
table = "pilot_languages"
column = "language_id"
foreign_table = "languages"
foreign_column = "id"
#...
``` 