### PR TITLE
sqlite3: minor fix for struct len check of columns whitelist and blacklist

### DIFF
--- a/drivers/sqlboiler-sqlite3/driver/sqlite3.go
+++ b/drivers/sqlboiler-sqlite3/driver/sqlite3.go
@@ -356,7 +356,7 @@ func (s SQLiteDriver) Columns(schema, tableName string, whitelist, blacklist []s
 
 ColumnLoop:
 	for _, column := range tinfo {
-		if len(whitelist) != 0 {
+		if len(whiteColumns) != 0 {
 			found := false
 			for _, white := range whiteColumns {
 				if white == column.Name {
@@ -367,7 +367,7 @@ ColumnLoop:
 			if !found {
 				continue
 			}
-		} else if len(blacklist) != 0 {
+		} else if len(blackColumns) != 0 {
 			for _, black := range blackColumns {
 				if black == column.Name {
 					continue ColumnLoop


### PR DESCRIPTION
When the whitelist doesn't specify any specific columns (i.e. just tables) then all columns of the whitelisted tables should be added to the column list. Instead, because the sqlite3 driver code checks the length of the incorrect slice, no columns are added to the column list at all. This then causes an error later on in the code. Merging this PR will fix the issue.