### PR TITLE
Fix parsing pgeo point in scientific notation format

### DIFF
--- a/types/pgeo/general.go
+++ b/types/pgeo/general.go
@@ -51,7 +51,7 @@ func formatPoints(points []Point) string {
 	return strings.Join(pts, ",")
 }
 
-var parsePointRegexp = regexp.MustCompile(`^\((-?[0-9]+(?:\.[0-9]+)?),(-?[0-9]+(?:\.[0-9]+)?)\)$`)
+var parsePointRegexp = regexp.MustCompile(`^\(([0-9\.Ee-]+),([0-9\.Ee-]+)\)$`)
 
 func parsePoint(pt string) (Point, error) {
 	var point = Point{}
@@ -73,7 +73,7 @@ func parsePoint(pt string) (Point, error) {
 	return point, nil
 }
 
-var parsePointsRegexp = regexp.MustCompile(`\((?:-?[0-9]+(?:\.[0-9]+)?),(?:-?[0-9]+(?:\.[0-9]+)?)\)`)
+var parsePointsRegexp = regexp.MustCompile(`\(([0-9\.Ee-]+),([0-9\.Ee-]+)\)`)
 
 func parsePoints(pts string) ([]Point, error) {
 	var points = []Point{}

--- a/types/pgeo/general_test.go
+++ b/types/pgeo/general_test.go
@@ -13,3 +13,13 @@ func BenchmarkParsePoint(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkParsePointScientificNotation(b *testing.B) {
+	pString := "(-1.73521E-5,-2.7159127785469e-7)"
+	for i := 0; i < 100000; i++ {
+		_, err := parsePoint(pString)
+		if err != nil {
+			b.Error("parsePoint failed", err)
+		}
+	}
+}


### PR DESCRIPTION
Databases, at least Postgres, can save points using scientific notation for small numbers. Using a completed regex for floating point is nontrivial, also not useful as ParseFloat should be smart enough to validate the number format. This commit relaxes the regex and rely on ParseFloat.