### PR TITLE
chore: fmt modify

### DIFF
--- a/drivers/sqlboiler-mysql/driver/mysql.go
+++ b/drivers/sqlboiler-mysql/driver/mysql.go
@@ -155,7 +155,7 @@ func MySQLBuildQueryString(user, pass, dbname, host string, port int, sslmode st
 func (m *MySQLDriver) TableNames(schema string, whitelist, blacklist []string) ([]string, error) {
 	var names []string
 
-	query := fmt.Sprintf(`select table_name from information_schema.tables where table_schema = ? and table_type = 'BASE TABLE'`)
+	query := `select table_name from information_schema.tables where table_schema = ? and table_type = 'BASE TABLE'`
 	args := []interface{}{schema}
 	if len(whitelist) > 0 {
 		tables := drivers.TablesFromList(whitelist)

--- a/types/pgeo/general.go
+++ b/types/pgeo/general.go
@@ -19,7 +19,7 @@ func iToS(src interface{}) (string, error) {
 	case []byte:
 		val = string(src.([]byte))
 	default:
-		err = errors.New(fmt.Sprintf("incompatible type %v", reflect.ValueOf(src).Kind().String()))
+		err = fmt.Errorf("incompatible type %v", reflect.ValueOf(src).Kind().String())
 	}
 
 	return val, err


### PR DESCRIPTION
unnecessary use of fmt.Sprintf
use fmt.Errorf(...) instead of errors.New(fmt.Sprintf(...))