### PR TITLE
psql: Fix UPSERT query to respect conflict_target

### DIFF
--- a/drivers/sqlboiler-psql/driver/override/main/singleton/psql_upsert.go.tpl
+++ b/drivers/sqlboiler-psql/driver/override/main/singleton/psql_upsert.go.tpl
@@ -21,11 +21,12 @@ func buildUpsertQueryPostgres(dia drivers.Dialect, tableName string, updateOnCon
 		columns,
 	)
 
+	buf.WriteByte('(')
+	buf.WriteString(strings.Join(conflict, ", "))
+
 	if !updateOnConflict || len(update) == 0 {
-		buf.WriteString("DO NOTHING")
+		buf.WriteString(") DO NOTHING")
 	} else {
-		buf.WriteByte('(')
-		buf.WriteString(strings.Join(conflict, ", "))
 		buf.WriteString(") DO UPDATE SET ")
 
 		for i, v := range update {


### PR DESCRIPTION
The Postgres driver, for the following method call:

    record.Upsert(ctx, db, false, []string{"foo"}, boil.None(), boil.Infer())

...would omit the conflict_target parameter[1], i.e. `foo`, from the query:

    INSERT INTO "cars" ("id", "foo") VALUES ($1,$2) ON CONFLICT DO NOTHING

This patch changes the behavior so that the conflict_target is respected, resulting in the following:

    INSERT INTO "cars" ("id", "foo") VALUES ($1,$2) ON CONFLICT ("foo") DO NOTHING

Fixes #1289

[1] https://www.postgresql.org/docs/15/sql-insert.html#SQL-ON-CONFLICT