### PR TITLE
fix column type conversion in SQLite3 driver

### DIFF
--- a/drivers/sqlboiler-sqlite3/driver/sqlite3.go
+++ b/drivers/sqlboiler-sqlite3/driver/sqlite3.go
@@ -534,7 +534,7 @@ func (SQLiteDriver) TranslateColumnType(c drivers.Column) drivers.Column {
 			c.Type = "null.String"
 		}
 	} else {
-		switch c.DBType {
+		switch strings.Split(c.DBType, "(")[0] {
 		case "INT", "INTEGER", "BIGINT":
 			c.Type = "int64"
 		case "TINYINT", "INT8":

--- a/drivers/sqlboiler-sqlite3/driver/sqlite3.golden.json
+++ b/drivers/sqlboiler-sqlite3/driver/sqlite3.golden.json
@@ -963,7 +963,7 @@
 				},
 				{
 					"name": "float_five",
-					"type": "string",
+					"type": "float32",
 					"db_type": "FLOAT(2,1)",
 					"default": "",
 					"comment": "",
@@ -993,7 +993,7 @@
 				},
 				{
 					"name": "float_seven",
-					"type": "string",
+					"type": "float32",
 					"db_type": "FLOAT(2,1)",
 					"default": "1.1",
 					"comment": "",
@@ -1398,7 +1398,7 @@
 				},
 				{
 					"name": "tinyint1_nnull",
-					"type": "string",
+					"type": "int8",
 					"db_type": "TINYINT(1)",
 					"default": "",
 					"comment": "",
@@ -1428,7 +1428,7 @@
 				},
 				{
 					"name": "tinyint2_nnull",
-					"type": "string",
+					"type": "int8",
 					"db_type": "TINYINT(2)",
 					"default": "",
 					"comment": "",


### PR DESCRIPTION
I found a bug in the SQLite3 driver related to column type conversion. The issue occurred when a column was not nullable, resulting in incorrect type conversion. Specifically, columns with types such as `FLOAT(2, 1)` or `TYNYINT(1)` were wrongly converted to string instead of `float32` and `int8` (although these types were correctly converted into `null.Float32` and `null.Int8` when the columns are nullable).

In this pull request, I have addressed this issue by fixing the column type conversion logic for non-nullable columns. Now, even if a column is not nullable, the types `FLOAT(2, 1)` and `TYNYINT(1)` are correctly converted to `float32` and `int8`, respectively. Additionally, I have updated the relevant test cases to thoroughly verify that these type conversions work as intended.