### PR TITLE
Fix types.JSON.MarshalJSON to handle nil values

### DIFF
--- a/types/json.go
+++ b/types/json.go
@@ -46,6 +46,9 @@ func (j *JSON) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON returns j as the JSON encoding of j.
 func (j JSON) MarshalJSON() ([]byte, error) {
+	if j == nil {
+		return []byte("null"), nil
+	}
 	return j, nil
 }
 

--- a/types/json_test.go
+++ b/types/json_test.go
@@ -76,6 +76,20 @@ func TestJSONUnmarshalJSON(t *testing.T) {
 	}
 }
 
+func TestJSONMarshalJSON_Null(t *testing.T) {
+	t.Parallel()
+
+	var j JSON
+	res, err := j.MarshalJSON()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !bytes.Equal(res, []byte(`null`)) {
+		t.Errorf("Expected %q, got %v", `null`, res)
+	}
+}
+
 func TestJSONMarshalJSON(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This patch adds support for properly marshalling a nil types.JSON value into `null`, mimicking the implementation of encoding/json[1].

Fixes https://github.com/volatiletech/sqlboiler/issues/1255#issuecomment-1740794315

[1] https://cs.opensource.google/go/go/+/master:src/encoding/json/encode.go;l=805-807