### PR TITLE
UpsertConflictObject -> UpsertConflictTarget+docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1792,6 +1792,18 @@ p1.Name = "Hogan"
 // INSERT INTO pilots ("id", "name") VALUES ($1, $2)
 // ON CONFLICT ("id") DO UPDATE SET "name" = EXCLUDED."name"
 err := p1.Upsert(ctx, db, true, []string{"id"}, boil.Whitelist("name"), boil.Whitelist("id", "name"))
+
+// Custom conflict_target expression:
+// INSERT INTO pilots ("id", "name") VALUES (9, 'Antwerp Design')
+// ON CONFLICT ON CONSTRAINT pilots_pkey DO NOTHING;
+conflictTarget := models.UpsertConflictTarget
+err := p1.Upsert(ctx, db, false, nil, boil.Whitelist("id", "name"), boil.None(), conflictTarget("ON CONSTRAINT pilots_pkey"))
+
+// Custom UPDATE SET expression:
+// INSERT INTO pilots ("id", "name") VALUES (9, 'Antwerp Design')
+// ON CONFLICT ("id") DO UPDATE SET (id, name) = (sub-SELECT)
+updateSet := models.UpsertUpdateSet
+err := p1.Upsert(ctx, db, true, []string{"id"}, boil.Whitelist("id", "name"), boil.None(), updateSet("(id, name) = (sub-SELECT)"))
 ```
 
 * **Postgres**

--- a/drivers/sqlboiler-psql/driver/override/main/singleton/psql_upsert.go.tpl
+++ b/drivers/sqlboiler-psql/driver/override/main/singleton/psql_upsert.go.tpl
@@ -1,13 +1,13 @@
 type UpsertOptions struct {
-	conflictObject string
+	conflictTarget string
 	updateSet string
 }
 
 type UpsertOptionFunc func(o *UpsertOptions)
 
-func UpsertConflictObject(conflictObject string) UpsertOptionFunc {
+func UpsertConflictTarget(conflictTarget string) UpsertOptionFunc {
 	return func(o *UpsertOptions) {
-		o.conflictObject = conflictObject
+		o.conflictTarget = conflictTarget
 	}
 }
 
@@ -45,8 +45,8 @@ func buildUpsertQueryPostgres(dia drivers.Dialect, tableName string, updateOnCon
 		columns,
 	)
 
-	if upsertOpts.conflictObject != "" {
-		buf.WriteString(upsertOpts.conflictObject)
+	if upsertOpts.conflictTarget != "" {
+		buf.WriteString(upsertOpts.conflictTarget)
 	} else if len(conflict) != 0 {
 		buf.WriteByte('(')
 		buf.WriteString(strings.Join(conflict, ", "))


### PR DESCRIPTION
This PR is a smallfix to previous PR #1317 not yet released.

More convensional naming with PostgreSQL official docs for not confusing users (https://www.postgresql.org/docs/15/sql-insert.html#:~:text=query%20%7D%0A%20%20%20%20%5B%20ON%20CONFLICT%20%5B-,conflict_target,-%5D%20conflict_action%20%5D%0A%20%20%20%20%5B%20RETURNING%20*%20%7C%20output_expression).

Also some example of use to README.md added.