### PR TITLE
fix: not using quotes on column names

### DIFF
--- a/drivers/sqlboiler-psql/driver/override/main/singleton/psql_upsert.go.tpl
+++ b/drivers/sqlboiler-psql/driver/override/main/singleton/psql_upsert.go.tpl
@@ -33,8 +33,8 @@ func buildUpsertQueryPostgres(dia drivers.Dialect, tableName string, updateOnCon
 
 	columns := "DEFAULT VALUES"
 	if len(whitelist) != 0 {
-		columns = fmt.Sprintf("(%s) VALUES (%s)",
-			strings.Join(whitelist, ", "),
+		columns = fmt.Sprintf("(\"%s\") VALUES (%s)",
+			strings.Join(whitelist, "\",\""),
 			strmangle.Placeholders(dia.UseIndexPlaceholders, len(whitelist), 1, 1))
 	}
 


### PR DESCRIPTION
Fix potential issue where column name like "createdAt" would not be using quotes