### PR TITLE
Fix erroneous return of sql.ErrNoRows in bind

### DIFF
--- a/queries/reflect.go
+++ b/queries/reflect.go
@@ -271,6 +271,10 @@ Rows:
 			ptrSlice.Set(reflect.Append(ptrSlice, newStruct))
 		}
 	}
+	err = rows.Err()
+	if err != nil {
+		return err
+	}
 
 	if bkind == kindStruct && !foundOne {
 		return sql.ErrNoRows


### PR DESCRIPTION
Returning sql.ErrNoRows without checking rows.Err() here causes other methods such as One and FindXYZ to return sql.ErrNoRows in cases in which the underlying driver returned a different error.