### PR TITLE
fix: use aliased field name for LastInsertID

### DIFF
--- a/templates/main/15_insert.go.tpl
+++ b/templates/main/15_insert.go.tpl
@@ -152,8 +152,7 @@ func (o *{{$alias.UpSingular}}) Insert({{if .NoContext}}exec boil.Executor{{else
 
 	{{$colName := index .Table.PKey.Columns 0 -}}
 	{{- $col := .Table.GetColumn $colName -}}
-	{{- $colTitled := $colName | titleCase}}
-	o.{{$colTitled}} = {{$col.Type}}(lastID)
+	o.{{$alias.Column $colName}} = {{$col.Type}}(lastID)
 	if lastID != 0 && len(cache.retMapping) == 1 && cache.retMapping[0] == {{$alias.DownSingular}}Mapping["{{$colName}}"] {
 		goto CacheNoHooks
 	}


### PR DESCRIPTION
When the table supports LastInsertID, the field name in the generated code currently does not use the aliased field name, but uses original column name. This causes a compilation error.

If test code is required I am ready to do so 😄 . Thanks!
