### PR TITLE
Improve loads by using maps for deduplication 

### DIFF
--- a/templates/main/07_relationship_to_one_eager.go.tpl
+++ b/templates/main/07_relationship_to_one_eager.go.tpl
@@ -70,11 +70,11 @@ func ({{$ltable.DownSingular}}L) Load{{$rel.Foreign}}({{if $.NoContext}}e boil.E
 	}
 
 	argsSlice := make([]interface{}, len(args))
-    i := 0
-    for arg := range args {
-        argsSlice[i] = arg
-        i++
-    }
+	i := 0
+	for arg := range args {
+		argsSlice[i] = arg
+		i++
+	}
 
 	query := NewQuery(
 	    qm.From(`{{if $.Dialect.UseSchema}}{{$.Schema}}.{{end}}{{.ForeignTable}}`),

--- a/templates/main/07_relationship_to_one_eager.go.tpl
+++ b/templates/main/07_relationship_to_one_eager.go.tpl
@@ -37,40 +37,29 @@ func ({{$ltable.DownSingular}}L) Load{{$rel.Foreign}}({{if $.NoContext}}e boil.E
 		}
 	}
 
-	args := make([]interface{}, 0, 1)
+	args := make(map[interface{}]struct{})
 	if singular {
 		if object.R == nil {
 			object.R = &{{$ltable.DownSingular}}R{}
 		}
 		{{if $usesPrimitives -}}
-		args = append(args, object.{{$col}})
+		args[object.{{$col}}] = struct{}{}
 		{{else -}}
 		if !queries.IsNil(object.{{$col}}) {
-			args = append(args, object.{{$col}})
+			args[object.{{$col}}] = struct{}{}
 		}
 		{{end}}
 	} else {
-		Outer:
 		for _, obj := range slice {
 			if obj.R == nil {
 				obj.R = &{{$ltable.DownSingular}}R{}
 			}
 
-			for _, a := range args {
-				{{if $usesPrimitives -}}
-				if a == obj.{{$col}} {
-				{{else -}}
-				if queries.Equal(a, obj.{{$col}}) {
-				{{end -}}
-					continue Outer
-				}
-			}
-
 			{{if $usesPrimitives -}}
-			args = append(args, obj.{{$col}})
+			args[obj.{{$col}}] = struct{}{}
 			{{else -}}
 			if !queries.IsNil(obj.{{$col}}) {
-				args = append(args, obj.{{$col}})
+				args[obj.{{$col}}] = struct{}{}
 			}
 			{{end}}
 		}
@@ -80,9 +69,16 @@ func ({{$ltable.DownSingular}}L) Load{{$rel.Foreign}}({{if $.NoContext}}e boil.E
 		return nil
 	}
 
+	argsSlice := make([]interface{}, len(args))
+    i := 0
+    for arg := range args {
+        argsSlice[i] = arg
+        i++
+    }
+
 	query := NewQuery(
 	    qm.From(`{{if $.Dialect.UseSchema}}{{$.Schema}}.{{end}}{{.ForeignTable}}`),
-	    qm.WhereIn(`{{if $.Dialect.UseSchema}}{{$.Schema}}.{{end}}{{.ForeignTable}}.{{.ForeignColumn}} in ?`, args...),
+	    qm.WhereIn(`{{if $.Dialect.UseSchema}}{{$.Schema}}.{{end}}{{.ForeignTable}}.{{.ForeignColumn}} in ?`, argsSlice...),
 	    {{if and $.AddSoftDeletes $canSoftDelete -}}
 	    qmhelper.WhereIsNull(`{{if $.Dialect.UseSchema}}{{$.Schema}}.{{end}}{{.ForeignTable}}.{{or $.AutoColumns.Deleted "deleted_at"}}`),
 	    {{- end}}

--- a/templates/main/08_relationship_one_to_one_eager.go.tpl
+++ b/templates/main/08_relationship_one_to_one_eager.go.tpl
@@ -58,11 +58,11 @@ func ({{$ltable.DownSingular}}L) Load{{$relAlias.Local}}({{if $.NoContext}}e boi
 	}
 
 	argsSlice := make([]interface{}, len(args))
-    i := 0
-    for arg := range args {
-        argsSlice[i] = arg
-        i++
-    }
+	i := 0
+	for arg := range args {
+		argsSlice[i] = arg
+		i++
+	}
 
 	query := NewQuery(
 	    qm.From(`{{if $.Dialect.UseSchema}}{{$.Schema}}.{{end}}{{.ForeignTable}}`),

--- a/templates/main/08_relationship_one_to_one_eager.go.tpl
+++ b/templates/main/08_relationship_one_to_one_eager.go.tpl
@@ -37,30 +37,19 @@ func ({{$ltable.DownSingular}}L) Load{{$relAlias.Local}}({{if $.NoContext}}e boi
 		}
 	}
 
-	args := make([]interface{}, 0, 1)
+	args := make(map[interface{}]struct{})
 	if singular {
 		if object.R == nil {
 			object.R = &{{$ltable.DownSingular}}R{}
 		}
-		args = append(args, object.{{$col}})
+		args[object.{{$col}}] = struct{}{}
 	} else {
-		Outer:
 		for _, obj := range slice {
 			if obj.R == nil {
 				obj.R = &{{$ltable.DownSingular}}R{}
 			}
 
-			for _, a := range args {
-				{{if $usesPrimitives -}}
-				if a == obj.{{$col}} {
-				{{else -}}
-				if queries.Equal(a, obj.{{$col}}) {
-				{{end -}}
-					continue Outer
-				}
-			}
-
-			args = append(args, obj.{{$col}})
+			args[obj.{{$col}}] = struct{}{}
 		}
 	}
 
@@ -68,9 +57,16 @@ func ({{$ltable.DownSingular}}L) Load{{$relAlias.Local}}({{if $.NoContext}}e boi
 		return nil
 	}
 
+	argsSlice := make([]interface{}, len(args))
+    i := 0
+    for arg := range args {
+        argsSlice[i] = arg
+        i++
+    }
+
 	query := NewQuery(
 	    qm.From(`{{if $.Dialect.UseSchema}}{{$.Schema}}.{{end}}{{.ForeignTable}}`),
-        qm.WhereIn(`{{if $.Dialect.UseSchema}}{{$.Schema}}.{{end}}{{.ForeignTable}}.{{.ForeignColumn}} in ?`, args...),
+        qm.WhereIn(`{{if $.Dialect.UseSchema}}{{$.Schema}}.{{end}}{{.ForeignTable}}.{{.ForeignColumn}} in ?`, argsSlice...),
 	    {{if and $.AddSoftDeletes $canSoftDelete -}}
 	    qmhelper.WhereIsNull(`{{if $.Dialect.UseSchema}}{{$.Schema}}.{{end}}{{.ForeignTable}}.{{or $.AutoColumns.Deleted "deleted_at"}}`),
 	    {{- end}}

--- a/templates/main/09_relationship_to_many_eager.go.tpl
+++ b/templates/main/09_relationship_to_many_eager.go.tpl
@@ -60,8 +60,8 @@ func ({{$ltable.DownSingular}}L) Load{{$relAlias.Local}}({{if $.NoContext}}e boi
 	argsSlice := make([]interface{}, len(args))
 	i := 0
 	for arg := range args {
-	    argsSlice[i] = arg
-	    i++
+		argsSlice[i] = arg
+		i++
 	}
 
 		{{if .ToJoinTable -}}

--- a/templates/main/09_relationship_to_many_eager.go.tpl
+++ b/templates/main/09_relationship_to_many_eager.go.tpl
@@ -38,35 +38,30 @@ func ({{$ltable.DownSingular}}L) Load{{$relAlias.Local}}({{if $.NoContext}}e boi
 		}
 	}
 
-	args := make([]interface{}, 0, 1)
+	args := make(map[interface{}]struct{})
 	if singular {
 		if object.R == nil {
 			object.R = &{{$ltable.DownSingular}}R{}
 		}
-		args = append(args, object.{{$col}})
+		args[object.{{$col}}] = struct{}{}
 	} else {
-		Outer:
 		for _, obj := range slice {
 			if obj.R == nil {
 				obj.R = &{{$ltable.DownSingular}}R{}
 			}
-
-			for _, a := range args {
-				{{if $usesPrimitives -}}
-				if a == obj.{{$col}} {
-				{{else -}}
-				if queries.Equal(a, obj.{{$col}}) {
-				{{end -}}
-					continue Outer
-				}
-			}
-
-			args = append(args, obj.{{$col}})
+			args[obj.{{$col}}] = struct{}{}
 		}
 	}
 
 	if len(args) == 0 {
 		return nil
+	}
+
+	argsSlice := make([]interface{}, len(args))
+	i := 0
+	for arg := range args {
+	    argsSlice[i] = arg
+	    i++
 	}
 
 		{{if .ToJoinTable -}}
@@ -76,7 +71,7 @@ func ({{$ltable.DownSingular}}L) Load{{$relAlias.Local}}({{if $.NoContext}}e boi
 		qm.Select("{{$foreignTable.Columns | columnNames | $.QuoteMap | prefixStringSlice (print $schemaForeignTable ".") | join ", "}}, {{id 0 | $.Quotes}}.{{.JoinLocalColumn | $.Quotes}}"),
 		qm.From("{{$schemaForeignTable}}"),
 		qm.InnerJoin("{{$schemaJoinTable}} as {{id 0 | $.Quotes}} on {{$schemaForeignTable}}.{{.ForeignColumn | $.Quotes}} = {{id 0 | $.Quotes}}.{{.JoinForeignColumn | $.Quotes}}"),
-		qm.WhereIn("{{id 0 | $.Quotes}}.{{.JoinLocalColumn | $.Quotes}} in ?", args...),
+		qm.WhereIn("{{id 0 | $.Quotes}}.{{.JoinLocalColumn | $.Quotes}} in ?", argsSlice...),
 		{{if and $.AddSoftDeletes $canSoftDelete -}}
 		qmhelper.WhereIsNull("{{$schemaForeignTable}}.{{or $.AutoColumns.Deleted "deleted_at" | $.Quotes}}"),
 		{{- end}}
@@ -84,7 +79,7 @@ func ({{$ltable.DownSingular}}L) Load{{$relAlias.Local}}({{if $.NoContext}}e boi
 		{{else -}}
 	query := NewQuery(
 	    qm.From(`{{if $.Dialect.UseSchema}}{{$.Schema}}.{{end}}{{.ForeignTable}}`),
-	    qm.WhereIn(`{{if $.Dialect.UseSchema}}{{$.Schema}}.{{end}}{{.ForeignTable}}.{{.ForeignColumn}} in ?`, args...),
+	    qm.WhereIn(`{{if $.Dialect.UseSchema}}{{$.Schema}}.{{end}}{{.ForeignTable}}.{{.ForeignColumn}} in ?`, argsSlice...),
 	    {{if and $.AddSoftDeletes $canSoftDelete -}}
 	    qmhelper.WhereIsNull(`{{if $.Dialect.UseSchema}}{{$.Schema}}.{{end}}{{.ForeignTable}}.{{or $.AutoColumns.Deleted "deleted_at"}}`),
 	    {{- end}}


### PR DESCRIPTION
Let maps handle the deduplication logic to increase performance / improve response times.

Commit [Deduplicate IDs in eager loads.](https://github.com/volatiletech/sqlboiler/commit/b5d2ec2964a142eed25465ab854856d2e1df5a02) introduced nested loops to filter duplicate foreign key IDs that are passed to the `WhereIn`-Function.
We noticed that the nested-loop-implementation of the deduplication logic results in bad performance as the number of eagerly loaded entities increases: [#267](https://github.com/volatiletech/sqlboiler/issues/267#issuecomment-1871931347).

We considered completely dropping the deduplication since databases treat IN clauses as sets.
The map-implementation improves performance and keeps the resulting SQL statements "backwards-compatible".

Please let us know if anything is missing!