### PR TITLE
fix: revert #1322 fixing bug in v4.16.0

### DIFF
--- a/drivers/sqlboiler-psql/driver/override/main/singleton/psql_upsert.go.tpl
+++ b/drivers/sqlboiler-psql/driver/override/main/singleton/psql_upsert.go.tpl
@@ -33,8 +33,8 @@ func buildUpsertQueryPostgres(dia drivers.Dialect, tableName string, updateOnCon
 
 	columns := "DEFAULT VALUES"
 	if len(whitelist) != 0 {
-		columns = fmt.Sprintf("(\"%s\") VALUES (%s)",
-			strings.Join(whitelist, "\",\""),
+		columns = fmt.Sprintf("(%s) VALUES (%s)",
+			strings.Join(whitelist, ", "),
 			strmangle.Placeholders(dia.UseIndexPlaceholders, len(whitelist), 1, 1))
 	}
 


### PR DESCRIPTION
Reverting changes from #1322 causing double quotes upsert to postgres. fixes #1341. Further work may be required to address the intention in the original PR