### PR TITLE
fix: replace rand.seed method to support golang 1.20

### DIFF
--- a/drivers/sqlboiler-sqlite3/driver/sqlite3_test.go
+++ b/drivers/sqlboiler-sqlite3/driver/sqlite3_test.go
@@ -22,7 +22,7 @@ var (
 )
 
 func TestDriver(t *testing.T) {
-	rand.Seed(time.Now().Unix())
+	rand.New(rand.NewSource(time.Now().Unix()))
 	b, err := os.ReadFile("testdatabase.sql")
 	if err != nil {
 		t.Fatal(err)

--- a/templates/test/singleton/boil_main_test.go.tpl
+++ b/templates/test/singleton/boil_main_test.go.tpl
@@ -19,7 +19,7 @@ func TestMain(m *testing.M) {
 		os.Exit(-1)
 	}
 
-	rand.Seed(time.Now().UnixNano())
+	rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	flag.Parse()
 

--- a/types/array_test.go
+++ b/types/array_test.go
@@ -326,7 +326,7 @@ func TestBoolArrayValue(t *testing.T) {
 }
 
 func BenchmarkBoolArrayValue(b *testing.B) {
-	rand.Seed(1)
+	rand.New(rand.NewSource(1))
 	x := make([]bool, 10)
 	for i := 0; i < len(x); i++ {
 		x[i] = rand.Intn(2) == 0
@@ -477,7 +477,7 @@ func TestBytesArrayValue(t *testing.T) {
 }
 
 func BenchmarkBytesArrayValue(b *testing.B) {
-	rand.Seed(1)
+	rand.New(rand.NewSource(1))
 	x := make([][]byte, 10)
 	for i := 0; i < len(x); i++ {
 		x[i] = make([]byte, len(x))
@@ -634,7 +634,7 @@ func TestFloat64ArrayValue(t *testing.T) {
 }
 
 func BenchmarkFloat64ArrayValue(b *testing.B) {
-	rand.Seed(1)
+	rand.New(rand.NewSource(1))
 	x := make([]float64, 10)
 	for i := 0; i < len(x); i++ {
 		x[i] = rand.NormFloat64()
@@ -787,7 +787,7 @@ func TestInt64ArrayValue(t *testing.T) {
 }
 
 func BenchmarkInt64ArrayValue(b *testing.B) {
-	rand.Seed(1)
+	rand.New(rand.NewSource(1))
 	x := make([]int64, 10)
 	for i := 0; i < len(x); i++ {
 		x[i] = rand.Int63()
@@ -1229,7 +1229,7 @@ func TestGenericArrayValueErrors(t *testing.T) {
 }
 
 func BenchmarkGenericArrayValueBools(b *testing.B) {
-	rand.Seed(1)
+	rand.New(rand.NewSource(1))
 	x := make([]bool, 10)
 	for i := 0; i < len(x); i++ {
 		x[i] = rand.Intn(2) == 0
@@ -1242,7 +1242,7 @@ func BenchmarkGenericArrayValueBools(b *testing.B) {
 }
 
 func BenchmarkGenericArrayValueFloat64s(b *testing.B) {
-	rand.Seed(1)
+	rand.New(rand.NewSource(1))
 	x := make([]float64, 10)
 	for i := 0; i < len(x); i++ {
 		x[i] = rand.NormFloat64()
@@ -1255,7 +1255,7 @@ func BenchmarkGenericArrayValueFloat64s(b *testing.B) {
 }
 
 func BenchmarkGenericArrayValueInt64s(b *testing.B) {
-	rand.Seed(1)
+	rand.New(rand.NewSource(1))
 	x := make([]int64, 10)
 	for i := 0; i < len(x); i++ {
 		x[i] = rand.Int63()


### PR DESCRIPTION
## What this PR does / why we need it
- Replace `rand.seed(1)` method to be `rand.New(rand.NewSource(1))` in order to allow sqlboiler to generate code compatible with Golang 1.20. Ensured methods exist in Golang 1.16, https://pkg.go.dev/math/rand@go1.16

[staticcheck](https://github.com/dominikh/go-tools) error:
```
 rand.Seed has been deprecated since Go 1.20 and an alternative has been available since Go 1.0: Programs that call Seed and then expect a specific sequence of results from the global random source (using functions such as Int) can be broken when a dependency changes how much it consumes from the global random source. To avoid such breakages, programs that need a specific result sequence should use NewRand(NewSource(seed)) to obtain a random generator that other packages cannot access.  (SA1019)
 ```
