### PR TITLE
hot-fix(templates/structure): fix to angry line eating for fields with ignored tags

### DIFF
--- a/templates/main/00_struct.go.tpl
+++ b/templates/main/00_struct.go.tpl
@@ -7,11 +7,11 @@ type {{$alias.UpSingular}} struct {
 	{{- $colAlias := $alias.Column $column.Name -}}
 	{{- $orig_col_name := $column.Name -}}
 	{{- range $column.Comment | splitLines -}} // {{ . }}
-	{{end -}}
+	{{ end -}}
 
 	{{if ignore $orig_tbl_name $orig_col_name $.TagIgnore -}}
 	{{$colAlias}} {{$column.Type}} `{{generateIgnoreTags $.Tags}}boil:"{{$column.Name}}" json:"-" toml:"-" yaml:"-"`
-	{{- else -}}
+	{{ else -}}
 
 	{{- /* render column alias and column type */ -}}
 	{{ $colAlias }} {{ $column.Type -}}


### PR DESCRIPTION
In [this commit](https://github.com/volatiletech/sqlboiler/commit/f27b374e8757d175a537912fd35935cb431794e8#diff-ad4a99e7b5707e0720670302be779e2d230f9a6d9d2a84ac2011f6ffe9367633R14) was added left pad deletion, which perform creating line record without breaking space, if tagIgnore was used. It break formatting of created code, and sqlboiler failes to perform saving