### PR TITLE
Added tinyint_as_int option to mysql example

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,7 @@ add-enum-types = true
   user    = "dbusername"
   pass    = "dbpassword"
   sslmode = "false"
+  tinyint_as_int = true
 
 [mssql]
   dbname  = "dbname"


### PR DESCRIPTION
Hello team,

I've added the tinyint_as_int option to the MySQL example. 
This is because I struggled to find out how to generate TINYINT as INT. 
This enhancement is related to the issue found here: https://github.com/volatiletech/sqlboiler/issues/80.