### PR TITLE
Lowercase column names before applying `TitleCase`

### DIFF
--- a/boilingcore/aliases.go
+++ b/boilingcore/aliases.go
@@ -2,6 +2,7 @@ package boilingcore
 
 import (
 	"fmt"
+	"strings"
 	"unicode"
 	"unicode/utf8"
 
@@ -76,14 +77,20 @@ func FillAliases(a *Aliases, tables []drivers.Table) {
 		}
 
 		for _, c := range t.Columns {
+			// If a string is all in uppercase, TitleCase will return the string
+			// as is. This is not what we want, so we lowercase the column name
+			columnName := strings.ToLower(c.Name)
+
 			if _, ok := table.Columns[c.Name]; !ok {
-				table.Columns[c.Name] = strmangle.TitleCase(c.Name)
+				columnName = strmangle.TitleCase(columnName)
 			}
 
-			r, _ := utf8.DecodeRuneInString(table.Columns[c.Name])
+			r, _ := utf8.DecodeRuneInString(columnName)
 			if unicode.IsNumber(r) {
-				table.Columns[c.Name] = "C" + table.Columns[c.Name]
+				columnName = "C" + columnName
 			}
+
+			table.Columns[c.Name] = columnName
 		}
 
 		a.Tables[t.Name] = table

--- a/boilingcore/aliases_test.go
+++ b/boilingcore/aliases_test.go
@@ -17,6 +17,7 @@ func TestAliasesTables(t *testing.T) {
 				{Name: "id"},
 				{Name: "name"},
 				{Name: "1number"},
+				{Name: "USER_ID"},
 			},
 		},
 	}
@@ -31,6 +32,7 @@ func TestAliasesTables(t *testing.T) {
 				"id":      "ID",
 				"name":    "Name",
 				"1number": "C1number",
+				"USER_ID": "UserID",
 			},
 			Relationships: make(map[string]RelationshipAlias),
 		}


### PR DESCRIPTION
I have a database which I cannot change and all the fields are in `SCREAMING_SNAKE_CASE`.

When I generate my models, `USER_ID` becomes `USER_ID` in my Go structs, which is not what I want and doesn't follow the expected Go conventions: I expect my field to be generated as `UserID`.

This small change will make my model be properly generated.