### PR TITLE
Use coalesce to use column_full_type when column_type is null

### DIFF
--- a/drivers/sqlboiler-psql/driver/psql.go
+++ b/drivers/sqlboiler-psql/driver/psql.go
@@ -567,7 +567,7 @@ func (p *PostgresDriver) Columns(schema, tableName string, whitelist, blacklist 
 
 	query := fmt.Sprintf(`SELECT 
 		column_name,
-		column_type,
+		COALESCE(column_type, column_full_type) as column_type,
 		column_full_type,
 		udt_name,
 		array_type,


### PR DESCRIPTION
User defined types generate NULL values for column_type.

Error produced while performing modgen generation:
`Fix Scan error on column index 1, name "column_type": converting NULL to string is unsupported, by coalescing column_type and if null replacing with column_full_type value.`