### PR TITLE
Implement (Un-)marshalText for Decimal and NullDecimal

### DIFF
--- a/types/decimal.go
+++ b/types/decimal.go
@@ -81,6 +81,24 @@ func (d *Decimal) UnmarshalJSON(data []byte) error {
 	return d.Big.UnmarshalJSON(data)
 }
 
+// MarshalText marshals a decimal value
+func (d Decimal) MarshalText() ([]byte, error) {
+	if d.Big == nil {
+		return nullBytes, nil
+	}
+
+	return d.Big.MarshalText()
+}
+
+// UnmarshalText allows marshalling text into a null pointer
+func (d *Decimal) UnmarshalText(data []byte) error {
+	if d.Big == nil {
+		d.Big = new(decimal.Big)
+	}
+
+	return d.Big.UnmarshalText(data)
+}
+
 // Randomize implements sqlboiler's randomize interface
 func (d *Decimal) Randomize(nextInt func() int64, fieldType string, shouldBeNull bool) {
 	d.Big = randomDecimal(nextInt, fieldType, false)
@@ -116,6 +134,31 @@ func (n *NullDecimal) UnmarshalJSON(data []byte) error {
 	}
 
 	return n.Big.UnmarshalJSON(data)
+}
+
+// MarshalText marshals a decimal value
+func (n NullDecimal) MarshalText() ([]byte, error) {
+	if n.Big == nil {
+		return nullBytes, nil
+	}
+
+	return n.Big.MarshalText()
+}
+
+// UnmarshalText allows marshalling text into a null pointer
+func (n *NullDecimal) UnmarshalText(data []byte) error {
+	if bytes.Equal(data, nullBytes) {
+		if n != nil {
+			n.Big = nil
+		}
+		return nil
+	}
+
+	if n.Big == nil {
+		n.Big = decimal.WithContext(DecimalContext)
+	}
+
+	return n.Big.UnmarshalText(data)
 }
 
 // String impl

--- a/types/decimal_test.go
+++ b/types/decimal_test.go
@@ -166,6 +166,38 @@ func TestDecimal_JSON(t *testing.T) {
 	}
 }
 
+func TestDecimal_Text(t *testing.T) {
+	t.Parallel()
+
+	d := new(Decimal)
+
+	err := d.UnmarshalText([]byte(`54.45`))
+	if err != nil {
+		t.Error(err)
+	}
+
+	want, _ := new(decimal.Big).SetString("54.45")
+	if d.Cmp(want) != 0 {
+		t.Error("D was wrong:", d)
+	}
+}
+
+func TestDecimal_TextNil(t *testing.T) {
+	t.Parallel()
+
+	var n Decimal
+	b, _ := n.MarshalText()
+	if string(b) != `null` {
+		t.Errorf("want: null, got: %s", b)
+	}
+
+	n2 := new(Decimal)
+	b, _ = n2.MarshalText()
+	if string(b) != `null` {
+		t.Errorf("want: null, got: %s", b)
+	}
+}
+
 func TestNullDecimal_JSON(t *testing.T) {
 	t.Parallel()
 
@@ -185,6 +217,23 @@ func TestNullDecimal_JSON(t *testing.T) {
 	}
 }
 
+func TestNullDecimal_Text(t *testing.T) {
+	t.Parallel()
+
+	n := new(NullDecimal)
+
+	err := n.UnmarshalText([]byte(`54.45`))
+	if err != nil {
+		t.Error(err)
+	}
+
+	want, _ := new(decimal.Big).SetString("54.45")
+	if n.Cmp(want) != 0 {
+		fmt.Println(want, n)
+		t.Error("N was wrong:", n)
+	}
+}
+
 func TestNullDecimal_JSONNil(t *testing.T) {
 	t.Parallel()
 
@@ -196,6 +245,22 @@ func TestNullDecimal_JSONNil(t *testing.T) {
 
 	n2 := new(NullDecimal)
 	b, _ = json.Marshal(n2)
+	if string(b) != `null` {
+		t.Errorf("want: null, got: %s", b)
+	}
+}
+
+func TestNullDecimal_TextNil(t *testing.T) {
+	t.Parallel()
+
+	var n NullDecimal
+	b, _ := n.MarshalText()
+	if string(b) != `null` {
+		t.Errorf("want: null, got: %s", b)
+	}
+
+	n2 := new(NullDecimal)
+	b, _ = n2.MarshalText()
 	if string(b) != `null` {
 		t.Errorf("want: null, got: %s", b)
 	}


### PR DESCRIPTION
UnmarshalText is required for parsing a text/csv file. Without, the code uses decimal directly and ends in a nil pointer exception because decimal.Big is nil on `scan`