### PR TITLE
templates: conditionally set created automatic column

### DIFF
--- a/templates/main/16_update.go.tpl
+++ b/templates/main/16_update.go.tpl
@@ -71,7 +71,7 @@ func (o *{{$alias.UpSingular}}) Update({{if .NoContext}}exec boil.Executor{{else
 		{{end}}
 		{{if not .NoAutoTimestamps}}
 		if !columns.IsWhitelist() {
-			wl = strmangle.SetComplement(wl, []string{"created_at"})
+			wl = strmangle.SetComplement(wl, []string{"{{or $.AutoColumns.Created "created_at"}}"})
 		}
 		{{end -}}
 		if len(wl) == 0 {


### PR DESCRIPTION
This change takes into account if the the created automatic column was set by the user in the update operation. If set, it will set the one provided by the user. If not set, it will set to the default "created_at" value.