### PR TITLE
fix comment position in first column of table

### DIFF
--- a/templates/main/00_struct.go.tpl
+++ b/templates/main/00_struct.go.tpl
@@ -3,10 +3,13 @@
 
 // {{$alias.UpSingular}} is an object representing the database table.
 type {{$alias.UpSingular}} struct {
-	{{- range $column := .Table.Columns -}}
+	{{- range $index, $column := .Table.Columns -}}
 	{{- $colAlias := $alias.Column $column.Name -}}
 	{{- $orig_col_name := $column.Name -}}
 	{{- range $column.Comment | splitLines -}} 
+	{{- if eq $index 0 -}}
+	{{ "\n" }}
+	{{- end -}}
 	// {{ . }}
 	{{ end -}}
 

--- a/templates/main/00_struct.go.tpl
+++ b/templates/main/00_struct.go.tpl
@@ -6,7 +6,8 @@ type {{$alias.UpSingular}} struct {
 	{{- range $column := .Table.Columns -}}
 	{{- $colAlias := $alias.Column $column.Name -}}
 	{{- $orig_col_name := $column.Name -}}
-	{{- range $column.Comment | splitLines -}} // {{ . }}
+	{{- range $column.Comment | splitLines -}} 
+	// {{ . }}
 	{{ end -}}
 
 	{{if ignore $orig_tbl_name $orig_col_name $.TagIgnore -}}


### PR DESCRIPTION
My attempt to resolve https://github.com/volatiletech/sqlboiler/issues/1377

The comment position in the first column of the table has been corrected to a new line.
