### PR TITLE
Fix output filenames that contain a forward slash or backslash

### DIFF
--- a/boilingcore/output.go
+++ b/boilingcore/output.go
@@ -306,6 +306,8 @@ func getLongExt(filename string) string {
 }
 
 func getOutputFilename(tableName string, isTest, isGo bool) string {
+	tableName = strings.ReplaceAll(strings.ReplaceAll(tableName, `/`, `_`), `\`, `_`)
+
 	if strings.HasPrefix(tableName, "_") {
 		tableName = "und" + tableName
 	}

--- a/boilingcore/output_test.go
+++ b/boilingcore/output_test.go
@@ -122,6 +122,12 @@ func TestGetOutputFilename(t *testing.T) {
 			IsGo:      true,
 			Expected:  "hello",
 		},
+		"contains_forward_slash": {
+			TableName: "slash/test",
+			IsTest:    false,
+			IsGo:      true,
+			Expected:  "slash_test_model",
+		},
 		"begins with underscore": {
 			TableName: "_hello",
 			IsTest:    false,


### PR DESCRIPTION
Example table
```sql
CREATE TABLE IF NOT EXISTS `Slash/Test` (
    id INT UNSIGNED NOT NULL AUTO_INCREMENT,

    `my_en/um` ENUM('test/1', '/test2', 'test3'),

    PRIMARY KEY (id)
);
```

Sqlboiler attempts to create a file called "Slash/Test.go", which it fails to do - and should not do. This fix changes the output to "Slash_Test.go".

NOTE: this output also requires volatiletech/strmangle#17 and volatiletech/strmangle#18

```go
// SlashTest is an object representing the database table.
type SlashTest struct {
	ID     uint                `csv:"id" hash:"id" boil:"id" json:"id" toml:"id" yaml:"id"`
	MyEnUm SlashTestNullMyEnUm `csv:"my_en/um" hash:"my_en/um" boil:"my_en/um" json:"my_en/um,omitempty" toml:"my_en/um" yaml:"my_en/um,omitempty"`

	R *slashTestR `csv:"-" hash:"-" boil:"-" json:"-" toml:"-" yaml:"-"`
	L slashTestL  `csv:"-" hash:"-" boil:"-" json:"-" toml:"-" yaml:"-"`
}

// and in boil_types.go

type SlashTestMyEnUm string

// Enum values for SlashTestMyEnUm
const (
	SlashTestMyEnUmTest1 SlashTestMyEnUm = "test/1"
	SlashTestMyEnUmTest2 SlashTestMyEnUm = "/test2"
	SlashTestMyEnUmTest3 SlashTestMyEnUm = "test3"
)
```
