### PR TITLE
wip: added --no-schema option scaffolding, needs tests

### DIFF
--- a/boilingcore/templates.go
+++ b/boilingcore/templates.go
@@ -39,6 +39,7 @@ type templateData struct {
 	RQ string
 
 	// Control various generation features
+	// NoOutputSchema, which is also used for generation, is defined in the drivers configuration
 	AddGlobal             bool
 	AddPanic              bool
 	AddSoftDeletes        bool

--- a/drivers/config.go
+++ b/drivers/config.go
@@ -93,6 +93,21 @@ func (c Config) DefaultString(key, def string) string {
 	return str
 }
 
+// DefaultBool retrieves a non-empty bool or the default value provided.
+func (c Config) DefaultBool(key string, def bool) bool {
+	b, ok := c[key]
+	if !ok {
+		return def
+	}
+
+	bul, ok := b.(bool)
+	if !ok {
+		return def
+	}
+
+	return bul
+}
+
 // Int retrieves an int, the bool says if it exists, is of the appropriate type,
 // and is non-zero. Coerces float64 to int because JSON and Javascript kinda suck.
 func (c Config) Int(key string) (int, bool) {

--- a/drivers/interface.go
+++ b/drivers/interface.go
@@ -17,6 +17,7 @@ const (
 	ConfigBlacklist      = "blacklist"
 	ConfigWhitelist      = "whitelist"
 	ConfigSchema         = "schema"
+	ConfigNoOutputSchema = "no-output-schema" // Determine if templates/output include a schema, even if we used one to gather info
 	ConfigAddEnumTypes   = "add-enum-types"
 	ConfigEnumNullPrefix = "enum-null-prefix"
 	ConfigConcurrency    = "concurrency"

--- a/drivers/sqlboiler-psql/driver/psql.go
+++ b/drivers/sqlboiler-psql/driver/psql.go
@@ -97,11 +97,20 @@ func (p *PostgresDriver) Assemble(config drivers.Config) (dbinfo *drivers.DBInfo
 	port := config.DefaultInt(drivers.ConfigPort, 5432)
 	sslmode := config.DefaultString(drivers.ConfigSSLMode, "require")
 	schema := config.DefaultString(drivers.ConfigSchema, "public")
+	noOutputSchema := config.DefaultBool(drivers.ConfigNoOutputSchema, false)
 	whitelist, _ := config.StringSlice(drivers.ConfigWhitelist)
 	blacklist, _ := config.StringSlice(drivers.ConfigBlacklist)
 	concurrency := config.DefaultInt(drivers.ConfigConcurrency, drivers.DefaultConcurrency)
 
-	useSchema := schema != "public"
+	switch {
+	case noOutputSchema:
+		break
+	case schema == "public":
+		noOutputSchema = true
+	default:
+		// just to be explicit, even though it's the default in the getter
+		noOutputSchema = false
+	}
 
 	p.addEnumTypes, _ = config[drivers.ConfigAddEnumTypes].(bool)
 	p.enumNullPrefix = strmangle.TitleCase(config.DefaultString(drivers.ConfigEnumNullPrefix, "Null"))
@@ -135,7 +144,7 @@ func (p *PostgresDriver) Assemble(config drivers.Config) (dbinfo *drivers.DBInfo
 			RQ: '"',
 
 			UseIndexPlaceholders: true,
-			UseSchema:            useSchema,
+			UseSchema:            !noOutputSchema,
 			UseDefaultKeyword:    true,
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -101,6 +101,7 @@ func main() {
 	rootCmd.PersistentFlags().BoolP("no-auto-timestamps", "", false, "Disable automatic timestamps for created_at/updated_at")
 	rootCmd.PersistentFlags().BoolP("no-driver-templates", "", false, "Disable parsing of templates defined by the database driver")
 	rootCmd.PersistentFlags().BoolP("no-back-referencing", "", false, "Disable back referencing in the loaded relationship structs")
+	rootCmd.PersistentFlags().BoolP("no-schema", "", false, "Disable generating a schema in the output")
 	rootCmd.PersistentFlags().BoolP("always-wrap-errors", "", false, "Wrap all returned errors with stacktraces, also sql.ErrNoRows")
 	rootCmd.PersistentFlags().BoolP("add-global-variants", "", false, "Enable generation for global variants")
 	rootCmd.PersistentFlags().BoolP("add-panic-variants", "", false, "Enable generation for panic variants")
@@ -213,11 +214,12 @@ func preRun(cmd *cobra.Command, args []string) error {
 
 	// Configure the driver
 	cmdConfig.DriverConfig = map[string]interface{}{
-		"whitelist":        viper.GetStringSlice(driverName + ".whitelist"),
-		"blacklist":        viper.GetStringSlice(driverName + ".blacklist"),
-		"add-enum-types":   cmdConfig.AddEnumTypes,
-		"enum-null-prefix": cmdConfig.EnumNullPrefix,
-		"foreign-keys":     cmdConfig.ForeignKeys,
+		"whitelist":                  viper.GetStringSlice(driverName + ".whitelist"),
+		"blacklist":                  viper.GetStringSlice(driverName + ".blacklist"),
+		drivers.ConfigNoOutputSchema: viper.GetBool("no-schema"),
+		"add-enum-types":             cmdConfig.AddEnumTypes,
+		"enum-null-prefix":           cmdConfig.EnumNullPrefix,
+		"foreign-keys":               cmdConfig.ForeignKeys,
 	}
 
 	keys := allKeys(driverName)


### PR DESCRIPTION
This adds the `--no-schema` option, which allows for overriding the default option in the driver.

This flag only allows forcefully ignoring the schema, setting `--no-schema=false` does not force usage of the schema.

This code works, but I'd like some feedback on what else needs to be updated to make this land.

I don't feel confident deciding which tests to update for this, nor if you'd like README stuffs to be updated.

Any guidance is welcome, and i'll do what I can.

Thanks!