### PR TITLE
Pin ubuntu-22.04 in workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:
   test:
     name: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         go: [1.19, 1.18]


### PR DESCRIPTION
This is because 24.04 does not contain `sqlcmd`