### PR TITLE
Add relation getters on base model structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,7 @@ not to pass them through the command line or environment variables:
 | no-auto-timestamps        | false    |
 | no-rows-affected          | false    |
 | no-driver-templates       | false    |
+| no-relation-getters       | false    |
 | tag-ignore                | []       |
 | strict-verify-mod-version | false    |
 
@@ -485,6 +486,7 @@ Flags:
       --no-hooks                   Disable hooks feature for your models
       --no-rows-affected           Disable rows affected in the generated API
       --no-tests                   Disable generated go test files
+      --no-relation-getters        Disable generating getters for relationship tables
   -o, --output string              The name of the folder to output to (default "models")
   -p, --pkgname string             The name you wish to assign to your generated package (default "models")
       --struct-tag-casing string   Decides the casing for go structure tag names. camel, title, alias or snake (default "snake")

--- a/boilingcore/boilingcore.go
+++ b/boilingcore/boilingcore.go
@@ -157,6 +157,7 @@ func (s *State) Run() error {
 		NoRowsAffected:        s.Config.NoRowsAffected,
 		NoDriverTemplates:     s.Config.NoDriverTemplates,
 		NoBackReferencing:     s.Config.NoBackReferencing,
+		NoRelationGetters:     s.Config.NoRelationGetters,
 		AlwaysWrapErrors:      s.Config.AlwaysWrapErrors,
 		StructTagCasing:       s.Config.StructTagCasing,
 		StructTagCases:        s.Config.StructTagCases,

--- a/boilingcore/config.go
+++ b/boilingcore/config.go
@@ -47,6 +47,7 @@ type Config struct {
 	NoRowsAffected        bool     `toml:"no_rows_affected,omitempty" json:"no_rows_affected,omitempty"`
 	NoDriverTemplates     bool     `toml:"no_driver_templates,omitempty" json:"no_driver_templates,omitempty"`
 	NoBackReferencing     bool     `toml:"no_back_reference,omitempty" json:"no_back_reference,omitempty"`
+	NoRelationGetters     bool     `toml:"no_relation_getters,omitempty" json:"no_relation_getters,omitempty"`
 	AlwaysWrapErrors      bool     `toml:"always_wrap_errors,omitempty" json:"always_wrap_errors,omitempty"`
 	Wipe                  bool     `toml:"wipe,omitempty" json:"wipe,omitempty"`
 

--- a/boilingcore/templates.go
+++ b/boilingcore/templates.go
@@ -52,6 +52,7 @@ type templateData struct {
 	NoRowsAffected        bool
 	NoDriverTemplates     bool
 	NoBackReferencing     bool
+	NoRelationGetters     bool
 	AlwaysWrapErrors      bool
 
 	// Tags control which tags are added to the struct

--- a/main.go
+++ b/main.go
@@ -102,6 +102,7 @@ func main() {
 	rootCmd.PersistentFlags().BoolP("no-driver-templates", "", false, "Disable parsing of templates defined by the database driver")
 	rootCmd.PersistentFlags().BoolP("no-back-referencing", "", false, "Disable back referencing in the loaded relationship structs")
 	rootCmd.PersistentFlags().BoolP("no-schema", "", false, "Disable generating a schema in the output")
+	rootCmd.PersistentFlags().BoolP("no-relation-getters", "", false, "Disable generating getters for relationship tables")
 	rootCmd.PersistentFlags().BoolP("always-wrap-errors", "", false, "Wrap all returned errors with stacktraces, also sql.ErrNoRows")
 	rootCmd.PersistentFlags().BoolP("add-global-variants", "", false, "Enable generation for global variants")
 	rootCmd.PersistentFlags().BoolP("add-panic-variants", "", false, "Enable generation for panic variants")
@@ -173,6 +174,7 @@ func preRun(cmd *cobra.Command, args []string) error {
 		NoAutoTimestamps:      viper.GetBool("no-auto-timestamps"),
 		NoDriverTemplates:     viper.GetBool("no-driver-templates"),
 		NoBackReferencing:     viper.GetBool("no-back-referencing"),
+		NoRelationGetters:     viper.GetBool("no-relation-getters"),
 		AlwaysWrapErrors:      viper.GetBool("always-wrap-errors"),
 		Wipe:                  viper.GetBool("wipe"),
 		StructTagCasing:       strings.ToLower(viper.GetString("struct-tag-casing")), // camel | snake | title

--- a/templates/main/00_struct.go.tpl
+++ b/templates/main/00_struct.go.tpl
@@ -197,6 +197,9 @@ func (*{{$alias.DownSingular}}R) NewStruct() *{{$alias.DownSingular}}R {
 {{range .Table.FKeys -}}
 {{- $ftable := $.Aliases.Table .ForeignTable -}}
 {{- $relAlias := $alias.Relationship .Name -}}
+
+{{- if not $.NoRelationGetters}}
+
 func (o *{{$alias.UpSingular}}) Get{{$relAlias.Foreign}}() *{{$ftable.UpSingular}} {
 	if (o == nil) {
 		return nil
@@ -204,6 +207,8 @@ func (o *{{$alias.UpSingular}}) Get{{$relAlias.Foreign}}() *{{$ftable.UpSingular
 
 	return o.R.Get{{$relAlias.Foreign}}()
 }
+
+{{end -}}
 
 func (r *{{$alias.DownSingular}}R) Get{{$relAlias.Foreign}}() *{{$ftable.UpSingular}} {
 	if (r == nil) {
@@ -218,6 +223,9 @@ func (r *{{$alias.DownSingular}}R) Get{{$relAlias.Foreign}}() *{{$ftable.UpSingu
 {{- range .Table.ToOneRelationships -}}
 {{- $ftable := $.Aliases.Table .ForeignTable -}}
 {{- $relAlias := $ftable.Relationship .Name -}}
+
+{{- if not $.NoRelationGetters}}
+
 func (o *{{$alias.UpSingular}}) Get{{$relAlias.Local}}() *{{$ftable.UpSingular}} {
 	if (o == nil) {
 		return nil
@@ -225,6 +233,8 @@ func (o *{{$alias.UpSingular}}) Get{{$relAlias.Local}}() *{{$ftable.UpSingular}}
 
 	return o.R.Get{{$relAlias.Local}}()
 }
+
+{{end -}}
 
 func (r *{{$alias.DownSingular}}R) Get{{$relAlias.Local}}() *{{$ftable.UpSingular}} {
 	if (r == nil) {
@@ -239,6 +249,9 @@ func (r *{{$alias.DownSingular}}R) Get{{$relAlias.Local}}() *{{$ftable.UpSingula
 {{- range .Table.ToManyRelationships -}}
 {{- $ftable := $.Aliases.Table .ForeignTable -}}
 {{- $relAlias := $.Aliases.ManyRelationship .ForeignTable .Name .JoinTable .JoinLocalFKeyName -}}
+
+{{- if not $.NoRelationGetters}}
+
 func (o *{{$alias.UpSingular}}) Get{{$relAlias.Local}}() {{printf "%sSlice" $ftable.UpSingular}} {
 	if (o == nil) {
 		return nil
@@ -246,6 +259,8 @@ func (o *{{$alias.UpSingular}}) Get{{$relAlias.Local}}() {{printf "%sSlice" $fta
 
 	return o.R.Get{{$relAlias.Local}}()
 }
+
+{{end -}}
 
 func (r *{{$alias.DownSingular}}R) Get{{$relAlias.Local}}() {{printf "%sSlice" $ftable.UpSingular}} {
 	if (r == nil) {

--- a/templates/main/00_struct.go.tpl
+++ b/templates/main/00_struct.go.tpl
@@ -197,11 +197,20 @@ func (*{{$alias.DownSingular}}R) NewStruct() *{{$alias.DownSingular}}R {
 {{range .Table.FKeys -}}
 {{- $ftable := $.Aliases.Table .ForeignTable -}}
 {{- $relAlias := $alias.Relationship .Name -}}
+func (o *{{$alias.UpSingular}}) Get{{$relAlias.Foreign}}() *{{$ftable.UpSingular}} {
+	if (o == nil) {
+		return nil
+	}
+
+	return o.R.Get{{$relAlias.Foreign}}()
+}
+
 func (r *{{$alias.DownSingular}}R) Get{{$relAlias.Foreign}}() *{{$ftable.UpSingular}} {
 	if (r == nil) {
-    return nil
+		return nil
 	}
-  return r.{{$relAlias.Foreign}}
+
+	return r.{{$relAlias.Foreign}}
 }
 
 {{end -}}
@@ -209,11 +218,20 @@ func (r *{{$alias.DownSingular}}R) Get{{$relAlias.Foreign}}() *{{$ftable.UpSingu
 {{- range .Table.ToOneRelationships -}}
 {{- $ftable := $.Aliases.Table .ForeignTable -}}
 {{- $relAlias := $ftable.Relationship .Name -}}
+func (o *{{$alias.UpSingular}}) Get{{$relAlias.Local}}() *{{$ftable.UpSingular}} {
+	if (o == nil) {
+		return nil
+	}
+
+	return o.R.Get{{$relAlias.Local}}()
+}
+
 func (r *{{$alias.DownSingular}}R) Get{{$relAlias.Local}}() *{{$ftable.UpSingular}} {
 	if (r == nil) {
-    return nil
+		return nil
 	}
-  return r.{{$relAlias.Local}}
+
+	return r.{{$relAlias.Local}}
 }
 
 {{end -}}
@@ -221,11 +239,20 @@ func (r *{{$alias.DownSingular}}R) Get{{$relAlias.Local}}() *{{$ftable.UpSingula
 {{- range .Table.ToManyRelationships -}}
 {{- $ftable := $.Aliases.Table .ForeignTable -}}
 {{- $relAlias := $.Aliases.ManyRelationship .ForeignTable .Name .JoinTable .JoinLocalFKeyName -}}
+func (o *{{$alias.UpSingular}}) Get{{$relAlias.Local}}() {{printf "%sSlice" $ftable.UpSingular}} {
+	if (o == nil) {
+		return nil
+	}
+
+	return o.R.Get{{$relAlias.Local}}()
+}
+
 func (r *{{$alias.DownSingular}}R) Get{{$relAlias.Local}}() {{printf "%sSlice" $ftable.UpSingular}} {
 	if (r == nil) {
-    return nil
+		return nil
 	}
-  return r.{{$relAlias.Local}}
+
+	return r.{{$relAlias.Local}}
 }
 
 {{end -}}


### PR DESCRIPTION
This prevents having to check the pointer before accessing a relation.

It was already safe to access a nil R's Get() method, but this removes some of the extra typing and nil checks as a convenience.

Previously:
```go
var office *models.Office
if employee != nil {
    office = employee.R.GetOffice()
}
```

With this helper:
```go
office := employee.GetOffice()
```

It is much more useful, however, when accessing nested relationships. Instead of

```go
var c *models.RelC
if m != nil && m.R.GetA() != nil && m.R.GetA().R.GetB() != nil {
    c = m.R.GetA().R.GetB().R.GetC()
}
```

we can do

```go
c := m.GetA().GetB().GetC()
```