### PR TITLE
Fix InsertWhitelist test in composite primary key table

### DIFF
--- a/templates/test/insert.go.tpl
+++ b/templates/test/insert.go.tpl
@@ -39,7 +39,7 @@ func test{{$alias.UpPlural}}InsertWhitelist(t *testing.T) {
 	{{if not .NoContext}}ctx := context.Background(){{end}}
 	tx := MustTx({{if .NoContext}}boil.Begin(){{else}}boil.BeginTx(ctx, nil){{end}})
 	defer func() { _ = tx.Rollback() }()
-	if err = o.Insert({{if not .NoContext}}ctx, {{end -}} tx, boil.Whitelist({{$alias.DownSingular}}ColumnsWithoutDefault...)); err != nil {
+	if err = o.Insert({{if not .NoContext}}ctx, {{end -}} tx, boil.Whitelist(strmangle.SetMerge({{$alias.DownSingular}}PrimaryKeyColumns, {{$alias.DownSingular}}ColumnsWithoutDefault)...)); err != nil {
 		t.Error(err)
 	}
 


### PR DESCRIPTION


- The table has a composite primary key with columns that have default values and columns that don't.
- ColumnsWithoutDefault columns don't guarantee unique records.

### What version of SQLBoiler are you using (`sqlboiler --version`)?

SQLBoiler v4.18.0

### What is your database and version (eg. Postgresql 10)

MySQL 8.0.34

### Please provide a relevant database schema so we can replicate your issue (Provided you are comfortable sharing this)

```sql
CREATE TABLE IF NOT EXISTS `dummy` (
  `id` INT NOT NULL,

  `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
  `updated_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,

  PRIMARY KEY (`id`, `created_at`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
```